### PR TITLE
[BE] 템플릿 경로 수정

### DIFF
--- a/backend/prologue/src/main/java/com/b208/prologue/api/service/BlogServiceImpl.java
+++ b/backend/prologue/src/main/java/com/b208/prologue/api/service/BlogServiceImpl.java
@@ -1,17 +1,16 @@
 package com.b208.prologue.api.service;
 
 import com.b208.prologue.api.request.github.*;
-import com.b208.prologue.api.response.github.*;
+import com.b208.prologue.api.response.github.GetShaResponse;
+import com.b208.prologue.api.response.github.RepositoryListResponse;
 import com.b208.prologue.common.Base64Converter;
 import lombok.RequiredArgsConstructor;
-import org.springframework.core.io.ClassPathResource;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.MediaType;
 import org.springframework.stereotype.Service;
 import org.springframework.web.reactive.function.client.WebClient;
 import reactor.core.publisher.Mono;
 
-import java.io.BufferedReader;
-import java.io.InputStreamReader;
 import java.util.Date;
 
 @Service
@@ -20,6 +19,12 @@ public class BlogServiceImpl implements BlogService {
 
     private final WebClient webClient;
     private final Base64Converter base64Converter;
+    private static String path;
+
+    @Value("${template.path}")
+    private void setTemplatePath(String path) {
+        this.path = path;
+    }
 
     @Override
     public void updateDeployBranch(String encodedAccessToken, String githubId) throws Exception {
@@ -77,7 +82,7 @@ public class BlogServiceImpl implements BlogService {
 
         CreateRepositoryRequest createRepositoryRequest = new CreateRepositoryRequest(githubId + ".github.io");
         webClient.post()
-                .uri("/repos/team-epilogue/" + template + "/generate")
+                .uri("/repos/" + path + "/" + template + "/generate")
                 .accept(MediaType.APPLICATION_JSON)
                 .headers(h -> h.setBearerAuth(accessToken))
                 .body(Mono.just(createRepositoryRequest), CreateRepositoryRequest.class)

--- a/backend/prologue/src/main/java/com/b208/prologue/api/service/DashBoardServiceImpl.java
+++ b/backend/prologue/src/main/java/com/b208/prologue/api/service/DashBoardServiceImpl.java
@@ -1,12 +1,15 @@
 package com.b208.prologue.api.service;
 
 import com.b208.prologue.api.request.DashBoardPostRequest;
-import com.b208.prologue.api.response.github.*;
+import com.b208.prologue.api.response.github.GetFileNameResponse;
+import com.b208.prologue.api.response.github.GetRepositorySizeResponse;
+import com.b208.prologue.api.response.github.PostGetListResponse;
 import com.b208.prologue.common.Base64Converter;
 import lombok.RequiredArgsConstructor;
 import org.json.simple.JSONArray;
 import org.json.simple.JSONObject;
 import org.json.simple.parser.JSONParser;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.MediaType;
 import org.springframework.stereotype.Service;
 import org.springframework.web.reactive.function.client.WebClient;
@@ -26,6 +29,12 @@ public class DashBoardServiceImpl implements DashBoardService {
     private final WebClient webClient;
     private final Base64Converter base64Converter;
     private final PostServiceImpl postService;
+    private static String path;
+
+    @Value("${template.path}")
+    private void setTemplatePath(String path) {
+        this.path = path;
+    }
 
     @Override
     public List<DashBoardPostRequest> getList(String encodedAccessToken, String githubId) throws Exception {
@@ -137,9 +146,9 @@ public class DashBoardServiceImpl implements DashBoardService {
                 .retrieve()
                 .bodyToMono(GetRepositorySizeResponse.class).block();
 
-        if(getRepositorySizeResponse.getSize() == 0.0) {
+        if (getRepositorySizeResponse.getSize() == 0.0) {
             GetRepositorySizeResponse tempBlogSize = webClient.get()
-                    .uri("/repos/team-epilogue/" + template)
+                    .uri("/repos/" + path + "/" + template)
                     .accept(MediaType.APPLICATION_JSON)
                     .headers(h -> h.setBearerAuth(accessToken))
                     .retrieve()


### PR DESCRIPTION
close #11 

organization를 변경하면서 기존에 템플릿을 포크하는 코드에 적힌 경로 일부를 수정했습니다.
organization을 직접적으로 입력하지않고 `properties`에서 가져오는 것으로 수정하여, 추후에 organization이 또 변경되더라도 코드에서 수정하지 않아도 되도록 수정했습니다.

---

organization 경로는 `application.properties`파일에 추가해야합니다.

```
template.path=organization name
```