### PR TITLE
[BE] 게시글 임시 저장 API 작성

### DIFF
--- a/backend/prologue/build.gradle
+++ b/backend/prologue/build.gradle
@@ -45,6 +45,7 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	runtimeOnly 'com.microsoft.sqlserver:mssql-jdbc'
 	runtimeOnly 'com.mysql:mysql-connector-j'
+	implementation group: 'com.google.code.gson', name: 'gson', version: '2.8.9'
 }
 
 test {

--- a/backend/prologue/src/main/java/com/b208/prologue/api/controller/TempPostController.java
+++ b/backend/prologue/src/main/java/com/b208/prologue/api/controller/TempPostController.java
@@ -1,7 +1,9 @@
 package com.b208.prologue.api.controller;
 
+import com.b208.prologue.api.request.SaveTempPostRequest;
 import com.b208.prologue.api.response.BaseResponseBody;
 import com.b208.prologue.api.response.GetTempPostResponse;
+import com.b208.prologue.api.response.SaveTempPostResponse;
 import com.b208.prologue.api.service.TempPostService;
 import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiResponse;
@@ -10,6 +12,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
+import javax.validation.Valid;
 import java.util.Map;
 
 @CrossOrigin("*")
@@ -29,8 +32,31 @@ public class TempPostController {
     })
     public ResponseEntity<? extends BaseResponseBody> getTempPost(@RequestParam String githubId,
                                                                   @RequestParam Long tempPostId) {
-        Map<String, Object> result = tempPostService.getTempPost(githubId, tempPostId);
-        if (result == null) return ResponseEntity.status(400).body(BaseResponseBody.of(400, "임시 저장 게시물 조회에 실패헸습니다."));
-        return ResponseEntity.status(200).body(GetTempPostResponse.of(result, 200, "임시 저장 게시물 조회 성공했습니다."));
+        try {
+            Map<String, Object> result = tempPostService.getTempPost(githubId, tempPostId);
+            if (result == null)
+                return ResponseEntity.status(400).body(BaseResponseBody.of(400, "임시 저장 게시물 조회에 실패헸습니다."));
+            return ResponseEntity.status(200).body(GetTempPostResponse.of(result, 200, "임시 저장 게시물 조회 성공했습니다."));
+        } catch (Exception e) {
+            e.printStackTrace();
+            return ResponseEntity.status(400).body(BaseResponseBody.of(400, "임시 저장 게시물 조회에 실패헸습니다."));
+        }
+    }
+
+    @PostMapping("")
+    @ApiOperation(value = "게시글 임시 저장", notes = "게시글을 임시 저장한다.")
+    @ApiResponses({
+            @ApiResponse(code = 200, message = "게시글 임시 저장 성공", response = SaveTempPostResponse.class),
+            @ApiResponse(code = 400, message = "게시글 임시 저장 실패", response = BaseResponseBody.class),
+            @ApiResponse(code = 500, message = "서버 오류", response = BaseResponseBody.class)
+    })
+    public ResponseEntity<? extends BaseResponseBody> saveTempPost(@Valid @RequestBody SaveTempPostRequest saveTempPostRequest) {
+        try {
+            Long tempPostId = tempPostService.saveTempPost(saveTempPostRequest);
+            return ResponseEntity.status(200).body(SaveTempPostResponse.of(tempPostId, 200, "게시글 임시 저장에 성공했습니다."));
+        } catch (Exception e) {
+            e.printStackTrace();
+            return ResponseEntity.status(400).body(BaseResponseBody.of(400, "게시글 임시 저장에 실패헸습니다."));
+        }
     }
 }

--- a/backend/prologue/src/main/java/com/b208/prologue/api/request/SaveTempPostRequest.java
+++ b/backend/prologue/src/main/java/com/b208/prologue/api/request/SaveTempPostRequest.java
@@ -1,0 +1,36 @@
+package com.b208.prologue.api.request;
+
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+import lombok.*;
+
+import javax.validation.constraints.NotBlank;
+import java.util.List;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Data
+@ApiModel("SaveTempPostRequest")
+public class SaveTempPostRequest {
+
+    @NotBlank
+    @ApiModelProperty(name = "깃허브 아이디", example = "test1234", required = true)
+    String githubId;
+
+    @ApiModelProperty(name = "게시글 제목", example = "게시글 제목", required = true)
+    String title;
+
+    @ApiModelProperty(name = "게시글 설명", example = "게시글 설명", required = true)
+    String description;
+
+    @ApiModelProperty(name = "카테고리", example = "카테고리", required = true)
+    String category;
+
+    @ApiModelProperty(name = "태그 리스트", example = "태그 리스트", required = true)
+    List<String> tags;
+
+    @ApiModelProperty(name = "게시글 내용", example = "게시글 내용", required = true)
+    String content;
+}

--- a/backend/prologue/src/main/java/com/b208/prologue/api/response/SaveTempPostResponse.java
+++ b/backend/prologue/src/main/java/com/b208/prologue/api/response/SaveTempPostResponse.java
@@ -1,0 +1,28 @@
+package com.b208.prologue.api.response;
+
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+import lombok.Data;
+import lombok.Getter;
+import lombok.Setter;
+
+import javax.validation.constraints.NotBlank;
+import java.util.List;
+import java.util.Map;
+
+@Getter
+@Setter
+@ApiModel("SaveTempPostResponse")
+public class SaveTempPostResponse extends BaseResponseBody {
+
+    @ApiModelProperty(name = "게시글 임시 저장 ID")
+    Long tempPostId;
+
+    public static SaveTempPostResponse of(Long tempPostId, Integer statusCode, String message){
+        SaveTempPostResponse res = new SaveTempPostResponse();
+        res.setTempPostId(tempPostId);
+        res.setStatusCode(statusCode);
+        res.setMessage(message);
+        return res;
+    }
+}

--- a/backend/prologue/src/main/java/com/b208/prologue/api/service/TempPostService.java
+++ b/backend/prologue/src/main/java/com/b208/prologue/api/service/TempPostService.java
@@ -1,7 +1,10 @@
 package com.b208.prologue.api.service;
 
+import com.b208.prologue.api.request.SaveTempPostRequest;
+
 import java.util.Map;
 
 public interface TempPostService {
-    Map<String, Object> getTempPost(final String githubId, final Long tempPostId);
+    Map<String, Object> getTempPost(final String githubId, final Long tempPostId) throws Exception;
+    Long saveTempPost(final SaveTempPostRequest saveTempPostRequest) throws Exception;
 }

--- a/backend/prologue/src/main/java/com/b208/prologue/api/service/TempPostServiceImpl.java
+++ b/backend/prologue/src/main/java/com/b208/prologue/api/service/TempPostServiceImpl.java
@@ -2,6 +2,7 @@ package com.b208.prologue.api.service;
 
 import com.b208.prologue.api.entity.TempPost;
 import com.b208.prologue.api.repository.TempPostRepository;
+import com.b208.prologue.api.request.SaveTempPostRequest;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -15,7 +16,7 @@ public class TempPostServiceImpl implements TempPostService {
     private final TempPostRepository tempPostRepository;
 
     @Override
-    public Map<String, Object> getTempPost(final String githubId, final Long tempPostId) {
+    public Map<String, Object> getTempPost(final String githubId, final Long tempPostId) throws Exception{
         final TempPost tempPost = tempPostRepository.findByTempPostIdAndGithubId(tempPostId, githubId);
 
         if (tempPost == null) return null;
@@ -30,6 +31,20 @@ public class TempPostServiceImpl implements TempPostService {
         result.put("createdAt", tempPost.getCreateTime());
         result.put("updatedAt", tempPost.getUpdateTime());
         return result;
+    }
+
+    @Override
+    public Long saveTempPost(final SaveTempPostRequest saveTempPostRequest) throws Exception{
+        final TempPost tempPost = TempPost.builder()
+                .githubId(saveTempPostRequest.getGithubId())
+                .title(saveTempPostRequest.getTitle())
+                .description(saveTempPostRequest.getDescription())
+                .category(saveTempPostRequest.getCategory())
+                .tags(saveTempPostRequest.getTags())
+                .content(saveTempPostRequest.getContent())
+                .build();
+
+        return tempPostRepository.save(tempPost).getTempPostId();
     }
 }
 

--- a/backend/prologue/src/test/java/com/b208/prologue/tempPost/TempPostServiceTest.java
+++ b/backend/prologue/src/test/java/com/b208/prologue/tempPost/TempPostServiceTest.java
@@ -2,6 +2,7 @@ package com.b208.prologue.tempPost;
 
 import com.b208.prologue.api.entity.TempPost;
 import com.b208.prologue.api.repository.TempPostRepository;
+import com.b208.prologue.api.request.SaveTempPostRequest;
 import com.b208.prologue.api.service.TempPostServiceImpl;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -28,10 +29,31 @@ class TempPostServiceTest {
     private static final String githubId = "test**";
     private static final Long tempPostId = 0L;
 
+    @Test
+    void 게시글_임시저장() throws Exception {
+        //given
+        final SaveTempPostRequest saveTempPostRequest = SaveTempPostRequest.builder()
+                .githubId(githubId)
+                .title("abc")
+                .build();
+        final TempPost tempPost = TempPost.builder()
+                .tempPostId(0L)
+                .title(saveTempPostRequest.getTitle())
+                .githubId(saveTempPostRequest.getGithubId())
+                .build();
+        doReturn(tempPost).when(tempPostRepository).save(any(TempPost.class));
+
+        //when
+        final Long tempPostId = tempPostService.saveTempPost(saveTempPostRequest);
+
+        //then
+        assertThat(tempPostId).isNotNull().isEqualTo(tempPost.getTempPostId());
+    }
+
     @Nested
     class 임시저장게시글_조회 {
         @Test
-        void 임시저장게시글없음() {
+        void 임시저장게시글없음() throws Exception {
             //given
 
             //when
@@ -42,7 +64,7 @@ class TempPostServiceTest {
         }
 
         @Test
-        void 임시저장게시글있음() {
+        void 임시저장게시글있음() throws Exception {
             //given
             final TempPost tempPost = TempPost.builder()
                     .title("abc")


### PR DESCRIPTION
close #16 

- POST 방식을 테스트할 때 RequestBody를 Json으로 받기위해 `Gson` 의존성을 추가했습니다.
- 게시글을 임시 저장하기 위한 서비스, 컨트롤러 단의 테스트 코드와 프로덕션 코드를 작성했습니다.