### PR TITLE
[BE] 임시 저장 게시글 삭제 API 작성하기

### DIFF
--- a/backend/prologue/src/main/java/com/b208/prologue/api/controller/TempPostController.java
+++ b/backend/prologue/src/main/java/com/b208/prologue/api/controller/TempPostController.java
@@ -59,4 +59,22 @@ public class TempPostController {
             return ResponseEntity.status(400).body(BaseResponseBody.of(400, "게시글 임시 저장에 실패헸습니다."));
         }
     }
+
+    @DeleteMapping("")
+    @ApiOperation(value = "임시 저장 게시글 삭제", notes = "임시 저장 게시물 삭제하기")
+    @ApiResponses({
+            @ApiResponse(code = 200, message = "임시 저장 게시글 삭제 성공", response = BaseResponseBody.class),
+            @ApiResponse(code = 400, message = "임시 저장 게시글 삭제 실패", response = BaseResponseBody.class),
+            @ApiResponse(code = 500, message = "서버 오류", response = BaseResponseBody.class)
+    })
+    public ResponseEntity<? extends BaseResponseBody> deleteTempPost(@RequestParam String githubId,
+                                                                     @RequestParam Long tempPostId) {
+        try {
+            tempPostService.deleteTempPost(githubId, tempPostId);
+            return ResponseEntity.status(200).body(BaseResponseBody.of(200, "임시 저장 게시글 삭제에 성공했습니다."));
+        } catch (Exception e) {
+            e.printStackTrace();
+            return ResponseEntity.status(400).body(BaseResponseBody.of(400, "임시 저장 게시글 삭제를 실패헸습니다."));
+        }
+    }
 }

--- a/backend/prologue/src/main/java/com/b208/prologue/api/repository/TempPostRepository.java
+++ b/backend/prologue/src/main/java/com/b208/prologue/api/repository/TempPostRepository.java
@@ -7,4 +7,5 @@ import org.springframework.stereotype.Repository;
 @Repository
 public interface TempPostRepository extends JpaRepository<TempPost, Long> {
     TempPost findByTempPostIdAndGithubId(final Long tempPostId, final String githubId);
+    void deleteByTempPostIdAndGithubId(final Long tempPostId, final String githubId);
 }

--- a/backend/prologue/src/main/java/com/b208/prologue/api/service/TempPostService.java
+++ b/backend/prologue/src/main/java/com/b208/prologue/api/service/TempPostService.java
@@ -7,4 +7,5 @@ import java.util.Map;
 public interface TempPostService {
     Map<String, Object> getTempPost(final String githubId, final Long tempPostId) throws Exception;
     Long saveTempPost(final SaveTempPostRequest saveTempPostRequest) throws Exception;
+    void deleteTempPost(final String githubId, final Long tempPostId) throws Exception;
 }

--- a/backend/prologue/src/main/java/com/b208/prologue/api/service/TempPostServiceImpl.java
+++ b/backend/prologue/src/main/java/com/b208/prologue/api/service/TempPostServiceImpl.java
@@ -5,6 +5,7 @@ import com.b208.prologue.api.repository.TempPostRepository;
 import com.b208.prologue.api.request.SaveTempPostRequest;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -16,7 +17,7 @@ public class TempPostServiceImpl implements TempPostService {
     private final TempPostRepository tempPostRepository;
 
     @Override
-    public Map<String, Object> getTempPost(final String githubId, final Long tempPostId) throws Exception{
+    public Map<String, Object> getTempPost(final String githubId, final Long tempPostId) throws Exception {
         final TempPost tempPost = tempPostRepository.findByTempPostIdAndGithubId(tempPostId, githubId);
 
         if (tempPost == null) return null;
@@ -34,7 +35,7 @@ public class TempPostServiceImpl implements TempPostService {
     }
 
     @Override
-    public Long saveTempPost(final SaveTempPostRequest saveTempPostRequest) throws Exception{
+    public Long saveTempPost(final SaveTempPostRequest saveTempPostRequest) throws Exception {
         final TempPost tempPost = TempPost.builder()
                 .githubId(saveTempPostRequest.getGithubId())
                 .title(saveTempPostRequest.getTitle())
@@ -45,6 +46,12 @@ public class TempPostServiceImpl implements TempPostService {
                 .build();
 
         return tempPostRepository.save(tempPost).getTempPostId();
+    }
+
+    @Override
+    @Transactional
+    public void deleteTempPost(final String githubId, final Long tempPostId) throws Exception {
+        tempPostRepository.deleteByTempPostIdAndGithubId(tempPostId, githubId);
     }
 }
 

--- a/backend/prologue/src/test/java/com/b208/prologue/tempPost/TempPostControllerTest.java
+++ b/backend/prologue/src/test/java/com/b208/prologue/tempPost/TempPostControllerTest.java
@@ -140,4 +140,39 @@ class TempPostControllerTest {
         }
     }
 
+    @Nested
+    class 임시저장게시글_삭제 {
+
+        @Test
+        void 실패() throws Exception {
+            //given
+            doThrow(new Exception()).when(tempPostService).deleteTempPost(githubId, tempPostId);
+
+            //when
+            final ResultActions resultActions = mockMvc.perform(
+                    MockMvcRequestBuilders.delete(url)
+                            .param("githubId", githubId)
+                            .param("tempPostId", String.valueOf(tempPostId))
+            );
+
+            //then
+            resultActions.andExpect(status().isBadRequest());
+        }
+
+        @Test
+        void 성공() throws Exception {
+            //given
+
+            //when
+            final ResultActions resultActions = mockMvc.perform(
+                    MockMvcRequestBuilders.delete(url)
+                            .param("githubId", githubId)
+                            .param("tempPostId", String.valueOf(tempPostId))
+            );
+
+            //then
+            resultActions.andExpect(status().isOk());
+        }
+    }
+
 }

--- a/backend/prologue/src/test/java/com/b208/prologue/tempPost/TempPostRepositoryTest.java
+++ b/backend/prologue/src/test/java/com/b208/prologue/tempPost/TempPostRepositoryTest.java
@@ -50,4 +50,20 @@ class TempPostRepositoryTest {
         }
     }
 
+    @Test
+    void 임시저장게시글_삭제() {
+        //given
+        final TempPost saveTempPost = tempPostRepository.save(TempPost.builder()
+                .title("abc")
+                .githubId(githubId)
+                .build());
+
+        //when
+        tempPostRepository.deleteByTempPostIdAndGithubId(saveTempPost.getTempPostId(), githubId);
+        final TempPost tempPost = tempPostRepository.findByTempPostIdAndGithubId(saveTempPost.getTempPostId(), githubId);
+
+        //then
+        assertThat(tempPost).isNull();
+    }
+
 }

--- a/backend/prologue/src/test/java/com/b208/prologue/tempPost/TempPostServiceTest.java
+++ b/backend/prologue/src/test/java/com/b208/prologue/tempPost/TempPostServiceTest.java
@@ -14,8 +14,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.Mockito.any;
-import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
 class TempPostServiceTest {
@@ -79,6 +78,19 @@ class TempPostServiceTest {
             assertThat(result).isNotNull();
             assertThat(result.get("title")).isEqualTo(tempPost.getTitle());
         }
+    }
+
+    @Test
+    void 임시저장게시글_삭제() throws Exception {
+        //given
+
+        //when
+        tempPostService.deleteTempPost(githubId, tempPostId);
+
+        //then
+
+        //verify
+        verify(tempPostRepository, times(1)).deleteByTempPostIdAndGithubId(any(Long.class), any(String.class));
     }
 
 }


### PR DESCRIPTION
close #18 

- 임시 저장한 게시글을 삭제하기 위한 레포지토리, 서비스, 컨트롤러 단의 테스트 코드와 프로덕션 코드를 작성했습니다.