### PR TITLE
[BE] 임시 저장 게시글 수정 API 작성하기

### DIFF
--- a/backend/prologue/src/main/java/com/b208/prologue/api/controller/TempPostController.java
+++ b/backend/prologue/src/main/java/com/b208/prologue/api/controller/TempPostController.java
@@ -1,5 +1,6 @@
 package com.b208.prologue.api.controller;
 
+import com.b208.prologue.api.request.ModifyTempPostRequest;
 import com.b208.prologue.api.request.SaveTempPostRequest;
 import com.b208.prologue.api.response.BaseResponseBody;
 import com.b208.prologue.api.response.GetTempPostResponse;
@@ -24,10 +25,10 @@ public class TempPostController {
     private final TempPostService tempPostService;
 
     @GetMapping("")
-    @ApiOperation(value = "임시 저장 게시물 조회", notes = "임시 저장 게시물 불러오기")
+    @ApiOperation(value = "임시 저장 게시글 조회", notes = "임시 저장 게시글 불러오기")
     @ApiResponses({
-            @ApiResponse(code = 200, message = "임시 저장 게시물 조회 성공", response = GetTempPostResponse.class),
-            @ApiResponse(code = 400, message = "임시 저장 게시물 조회 실패", response = BaseResponseBody.class),
+            @ApiResponse(code = 200, message = "임시 저장 게시글 조회 성공", response = GetTempPostResponse.class),
+            @ApiResponse(code = 400, message = "임시 저장 게시글 조회 실패", response = BaseResponseBody.class),
             @ApiResponse(code = 500, message = "서버 오류", response = BaseResponseBody.class)
     })
     public ResponseEntity<? extends BaseResponseBody> getTempPost(@RequestParam String githubId,
@@ -35,11 +36,11 @@ public class TempPostController {
         try {
             Map<String, Object> result = tempPostService.getTempPost(githubId, tempPostId);
             if (result == null)
-                return ResponseEntity.status(400).body(BaseResponseBody.of(400, "임시 저장 게시물 조회에 실패헸습니다."));
-            return ResponseEntity.status(200).body(GetTempPostResponse.of(result, 200, "임시 저장 게시물 조회 성공했습니다."));
+                return ResponseEntity.status(400).body(BaseResponseBody.of(400, "임시 저장 게시글 조회에 실패헸습니다."));
+            return ResponseEntity.status(200).body(GetTempPostResponse.of(result, 200, "임시 저장 게시글 조회 성공했습니다."));
         } catch (Exception e) {
             e.printStackTrace();
-            return ResponseEntity.status(400).body(BaseResponseBody.of(400, "임시 저장 게시물 조회에 실패헸습니다."));
+            return ResponseEntity.status(400).body(BaseResponseBody.of(400, "임시 저장 게시글 조회에 실패헸습니다."));
         }
     }
 
@@ -57,6 +58,23 @@ public class TempPostController {
         } catch (Exception e) {
             e.printStackTrace();
             return ResponseEntity.status(400).body(BaseResponseBody.of(400, "게시글 임시 저장에 실패헸습니다."));
+        }
+    }
+
+    @PutMapping("")
+    @ApiOperation(value = "임시 저장 게시글 수정", notes = "임시 저장한 게시글을 수정한다.")
+    @ApiResponses({
+            @ApiResponse(code = 200, message = "임시 저장 게시글 수정 성공", response = BaseResponseBody.class),
+            @ApiResponse(code = 400, message = "임시 저장 게시글 수정 실패", response = BaseResponseBody.class),
+            @ApiResponse(code = 500, message = "서버 오류", response = BaseResponseBody.class)
+    })
+    public ResponseEntity<? extends BaseResponseBody> modifyTempPost(@Valid @RequestBody ModifyTempPostRequest modifyTempPostRequest) {
+        try {
+            tempPostService.modifyTempPost(modifyTempPostRequest);
+            return ResponseEntity.status(200).body(BaseResponseBody.of(200, "임시 저장 게시글 수정에 성공했습니다."));
+        } catch (Exception e) {
+            e.printStackTrace();
+            return ResponseEntity.status(400).body(BaseResponseBody.of(400, "임시 저장 게시글 수정에 실패헸습니다."));
         }
     }
 

--- a/backend/prologue/src/main/java/com/b208/prologue/api/exception/TempPostException.java
+++ b/backend/prologue/src/main/java/com/b208/prologue/api/exception/TempPostException.java
@@ -1,0 +1,9 @@
+package com.b208.prologue.api.exception;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public class TempPostException extends RuntimeException{
+}

--- a/backend/prologue/src/main/java/com/b208/prologue/api/request/ModifyTempPostRequest.java
+++ b/backend/prologue/src/main/java/com/b208/prologue/api/request/ModifyTempPostRequest.java
@@ -1,0 +1,41 @@
+package com.b208.prologue.api.request;
+
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+import lombok.*;
+
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.NotNull;
+import java.util.List;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Data
+@ApiModel("ModifyTempPostRequest")
+public class ModifyTempPostRequest {
+
+    @NotBlank
+    @ApiModelProperty(name = "깃허브 아이디", example = "test1234", required = true)
+    String githubId;
+
+    @NotNull
+    @ApiModelProperty(name = "임시 게시글 아이디", example = "1L", required = true)
+    Long tempPostId;
+
+    @ApiModelProperty(name = "게시글 제목", example = "게시글 제목", required = true)
+    String title;
+
+    @ApiModelProperty(name = "게시글 설명", example = "게시글 설명", required = true)
+    String description;
+
+    @ApiModelProperty(name = "카테고리", example = "카테고리", required = true)
+    String category;
+
+    @ApiModelProperty(name = "태그 리스트", example = "태그 리스트", required = true)
+    List<String> tags;
+
+    @ApiModelProperty(name = "게시글 내용", example = "게시글 내용", required = true)
+    String content;
+}

--- a/backend/prologue/src/main/java/com/b208/prologue/api/service/TempPostService.java
+++ b/backend/prologue/src/main/java/com/b208/prologue/api/service/TempPostService.java
@@ -1,5 +1,6 @@
 package com.b208.prologue.api.service;
 
+import com.b208.prologue.api.request.ModifyTempPostRequest;
 import com.b208.prologue.api.request.SaveTempPostRequest;
 
 import java.util.Map;
@@ -7,5 +8,6 @@ import java.util.Map;
 public interface TempPostService {
     Map<String, Object> getTempPost(final String githubId, final Long tempPostId) throws Exception;
     Long saveTempPost(final SaveTempPostRequest saveTempPostRequest) throws Exception;
+    void modifyTempPost(final ModifyTempPostRequest modifyTempPostRequest) throws Exception;
     void deleteTempPost(final String githubId, final Long tempPostId) throws Exception;
 }

--- a/backend/prologue/src/main/java/com/b208/prologue/api/service/TempPostServiceImpl.java
+++ b/backend/prologue/src/main/java/com/b208/prologue/api/service/TempPostServiceImpl.java
@@ -1,7 +1,9 @@
 package com.b208.prologue.api.service;
 
 import com.b208.prologue.api.entity.TempPost;
+import com.b208.prologue.api.exception.TempPostException;
 import com.b208.prologue.api.repository.TempPostRepository;
+import com.b208.prologue.api.request.ModifyTempPostRequest;
 import com.b208.prologue.api.request.SaveTempPostRequest;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -17,10 +19,10 @@ public class TempPostServiceImpl implements TempPostService {
     private final TempPostRepository tempPostRepository;
 
     @Override
-    public Map<String, Object> getTempPost(final String githubId, final Long tempPostId) throws Exception {
+    public Map<String, Object> getTempPost(final String githubId, final Long tempPostId) throws TempPostException {
         final TempPost tempPost = tempPostRepository.findByTempPostIdAndGithubId(tempPostId, githubId);
 
-        if (tempPost == null) return null;
+        if (tempPost == null) throw new TempPostException();
 
         Map<String, Object> result = new HashMap<>();
         result.put("tempPostId", tempPost.getTempPostId());
@@ -46,6 +48,26 @@ public class TempPostServiceImpl implements TempPostService {
                 .build();
 
         return tempPostRepository.save(tempPost).getTempPostId();
+    }
+
+    @Override
+    @Transactional
+    public void modifyTempPost(final ModifyTempPostRequest modifyTempPostRequest) throws TempPostException {
+        final TempPost tempPost = tempPostRepository.findByTempPostIdAndGithubId(modifyTempPostRequest.getTempPostId(), modifyTempPostRequest.getGithubId());
+
+        if (tempPost == null) throw new TempPostException();
+
+        final TempPost modifyTempPost = TempPost.builder()
+                .tempPostId(modifyTempPostRequest.getTempPostId())
+                .githubId(modifyTempPostRequest.getGithubId())
+                .title(modifyTempPostRequest.getTitle())
+                .description(modifyTempPostRequest.getDescription())
+                .category(modifyTempPostRequest.getCategory())
+                .tags(modifyTempPostRequest.getTags())
+                .content(modifyTempPostRequest.getContent())
+                .build();
+
+        tempPostRepository.save(modifyTempPost);
     }
 
     @Override

--- a/backend/prologue/src/test/java/com/b208/prologue/tempPost/TempPostControllerTest.java
+++ b/backend/prologue/src/test/java/com/b208/prologue/tempPost/TempPostControllerTest.java
@@ -1,6 +1,8 @@
 package com.b208.prologue.tempPost;
 
 import com.b208.prologue.api.controller.TempPostController;
+import com.b208.prologue.api.exception.TempPostException;
+import com.b208.prologue.api.request.ModifyTempPostRequest;
 import com.b208.prologue.api.request.SaveTempPostRequest;
 import com.b208.prologue.api.service.TempPostServiceImpl;
 import com.google.gson.Gson;
@@ -110,7 +112,7 @@ class TempPostControllerTest {
         @Test
         void 임시저장게시글없음() throws Exception {
             //given
-            doReturn(null).when(tempPostService).getTempPost(githubId, tempPostId);
+            doThrow(new TempPostException()).when(tempPostService).getTempPost(githubId, tempPostId);
 
             //when
             final ResultActions resultActions = mockMvc.perform(
@@ -133,6 +135,84 @@ class TempPostControllerTest {
                     MockMvcRequestBuilders.get(url)
                             .param("githubId", githubId)
                             .param("tempPostId", String.valueOf(tempPostId))
+            );
+
+            //then
+            resultActions.andExpect(status().isOk());
+        }
+    }
+
+    @Nested
+    class 임시저장게시글_수정 {
+        final ModifyTempPostRequest modifyTempPostRequest = ModifyTempPostRequest.builder()
+                .githubId(githubId)
+                .tempPostId(0L)
+                .title("abc")
+                .build();
+
+        @Test
+        void 실패_깃허브ID없음() throws Exception {
+            //given
+            final ModifyTempPostRequest modifyTempPostRequest = ModifyTempPostRequest.builder()
+                    .tempPostId(0L)
+                    .title("abc")
+                    .build();
+
+            //when
+            final ResultActions resultActions = mockMvc.perform(
+                    MockMvcRequestBuilders.put(url)
+                            .content(gson.toJson(modifyTempPostRequest))
+                            .contentType(MediaType.APPLICATION_JSON)
+            );
+
+            //then
+            resultActions.andExpect(status().isBadRequest());
+        }
+
+        @Test
+        void 실패_임시저장게시글ID없음() throws Exception {
+            //given
+            final ModifyTempPostRequest modifyTempPostRequest = ModifyTempPostRequest.builder()
+                    .githubId(githubId)
+                    .title("abc")
+                    .build();
+
+            //when
+            final ResultActions resultActions = mockMvc.perform(
+                    MockMvcRequestBuilders.put(url)
+                            .content(gson.toJson(modifyTempPostRequest))
+                            .contentType(MediaType.APPLICATION_JSON)
+            );
+
+            //then
+            resultActions.andExpect(status().isBadRequest());
+        }
+
+        @Test
+        void 실패_임시저장게시글없음() throws Exception {
+            //given
+            doThrow(new TempPostException()).when(tempPostService).modifyTempPost(modifyTempPostRequest);
+
+            //when
+            final ResultActions resultActions = mockMvc.perform(
+                    MockMvcRequestBuilders.put(url)
+                            .content(gson.toJson(modifyTempPostRequest))
+                            .contentType(MediaType.APPLICATION_JSON)
+            );
+
+            //then
+            resultActions.andExpect(status().isBadRequest());
+        }
+
+        @Test
+        void 성공() throws Exception {
+            //given
+
+            //when
+            final ResultActions resultActions = mockMvc.perform(
+                    MockMvcRequestBuilders.post(url)
+                            .content(gson.toJson(modifyTempPostRequest))
+                            .contentType(MediaType.APPLICATION_JSON)
             );
 
             //then

--- a/backend/prologue/src/test/java/com/b208/prologue/tempPost/TempPostServiceTest.java
+++ b/backend/prologue/src/test/java/com/b208/prologue/tempPost/TempPostServiceTest.java
@@ -1,7 +1,9 @@
 package com.b208.prologue.tempPost;
 
 import com.b208.prologue.api.entity.TempPost;
+import com.b208.prologue.api.exception.TempPostException;
 import com.b208.prologue.api.repository.TempPostRepository;
+import com.b208.prologue.api.request.ModifyTempPostRequest;
 import com.b208.prologue.api.request.SaveTempPostRequest;
 import com.b208.prologue.api.service.TempPostServiceImpl;
 import org.junit.jupiter.api.Nested;
@@ -14,6 +16,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
@@ -56,10 +59,12 @@ class TempPostServiceTest {
             //given
 
             //when
-            final Map<String, Object> result = tempPostService.getTempPost(githubId, tempPostId);
+            assertThrows(TempPostException.class, () -> tempPostService.getTempPost(githubId, tempPostId));
 
             //then
-            assertThat(result).isNull();
+
+            //verify
+            verify(tempPostRepository, times(1)).findByTempPostIdAndGithubId(any(Long.class), any(String.class));
         }
 
         @Test
@@ -77,6 +82,48 @@ class TempPostServiceTest {
             //then
             assertThat(result).isNotNull();
             assertThat(result.get("title")).isEqualTo(tempPost.getTitle());
+        }
+    }
+
+    @Nested
+    class 임시저장게시글_수정 {
+        final ModifyTempPostRequest modifyTempPostRequest = ModifyTempPostRequest.builder()
+                .githubId(githubId)
+                .tempPostId(0L)
+                .title("abc")
+                .build();
+        final TempPost tempPost = TempPost.builder()
+                .tempPostId(modifyTempPostRequest.getTempPostId())
+                .githubId(modifyTempPostRequest.getGithubId())
+                .title(modifyTempPostRequest.getTitle())
+                .build();
+
+        @Test
+        void 임시저장게시글없음() throws Exception {
+            //given
+
+            //when
+            assertThrows(TempPostException.class, () -> tempPostService.modifyTempPost(modifyTempPostRequest));
+
+            //then
+
+            //verify
+            verify(tempPostRepository, times(1)).findByTempPostIdAndGithubId(any(Long.class), any(String.class));
+        }
+
+        @Test
+        void 임시저장게시글있음() throws Exception {
+            //given
+            doReturn(tempPost).when(tempPostRepository).findByTempPostIdAndGithubId(any(), any());
+
+            //when
+            tempPostService.modifyTempPost(modifyTempPostRequest);
+
+            //then
+
+            //verify
+            verify(tempPostRepository, times(1)).findByTempPostIdAndGithubId(any(Long.class), any(String.class));
+            verify(tempPostRepository, times(1)).save(any(TempPost.class));
         }
     }
 


### PR DESCRIPTION
close #20

- 임시게시글이 없는 경우 예외처리를 위한 `TempPostException`을 만들었습니다.
- 임시 저장한 게시글을 수정하기 위한 레포지토리, 서비스, 컨트롤러 단의 테스트 코드와 프로덕션 코드를 작성했습니다.