### PR TITLE
[BE] 임시 저장 게시글 수 조회 API 작성하기

### DIFF
--- a/backend/prologue/src/main/java/com/b208/prologue/api/controller/TempPostController.java
+++ b/backend/prologue/src/main/java/com/b208/prologue/api/controller/TempPostController.java
@@ -4,6 +4,7 @@ import com.b208.prologue.api.request.ModifyTempPostRequest;
 import com.b208.prologue.api.request.SaveTempPostRequest;
 import com.b208.prologue.api.response.BaseResponseBody;
 import com.b208.prologue.api.response.GetTempPostResponse;
+import com.b208.prologue.api.response.CountTempPostsResponse;
 import com.b208.prologue.api.response.SaveTempPostResponse;
 import com.b208.prologue.api.service.TempPostService;
 import io.swagger.annotations.ApiOperation;
@@ -93,6 +94,23 @@ public class TempPostController {
         } catch (Exception e) {
             e.printStackTrace();
             return ResponseEntity.status(400).body(BaseResponseBody.of(400, "임시 저장 게시글 삭제를 실패헸습니다."));
+        }
+    }
+
+    @GetMapping("/count")
+    @ApiOperation(value = "임시 저장 게시글 수 조회", notes = "임시 저장 게시글 수 조회")
+    @ApiResponses({
+            @ApiResponse(code = 200, message = "임시 저장 게시글 수 조회 성공", response = CountTempPostsResponse.class),
+            @ApiResponse(code = 400, message = "임시 저장 게시글 수 조회 실패", response = BaseResponseBody.class),
+            @ApiResponse(code = 500, message = "서버 오류", response = BaseResponseBody.class)
+    })
+    public ResponseEntity<? extends BaseResponseBody> countTempPosts(@RequestParam String githubId) {
+        try {
+            int count = tempPostService.countTempPosts(githubId);
+            return ResponseEntity.status(200).body(CountTempPostsResponse.of(count, 200, "임시 저장 게시글 수 조회 성공했습니다."));
+        } catch (Exception e) {
+            e.printStackTrace();
+            return ResponseEntity.status(400).body(BaseResponseBody.of(400, "임시 저장 게시글 수 조회에 실패헸습니다."));
         }
     }
 }

--- a/backend/prologue/src/main/java/com/b208/prologue/api/repository/TempPostRepository.java
+++ b/backend/prologue/src/main/java/com/b208/prologue/api/repository/TempPostRepository.java
@@ -8,4 +8,5 @@ import org.springframework.stereotype.Repository;
 public interface TempPostRepository extends JpaRepository<TempPost, Long> {
     TempPost findByTempPostIdAndGithubId(final Long tempPostId, final String githubId);
     void deleteByTempPostIdAndGithubId(final Long tempPostId, final String githubId);
+    int countByGithubId(final String githubId);
 }

--- a/backend/prologue/src/main/java/com/b208/prologue/api/response/CountTempPostsResponse.java
+++ b/backend/prologue/src/main/java/com/b208/prologue/api/response/CountTempPostsResponse.java
@@ -1,0 +1,23 @@
+package com.b208.prologue.api.response;
+
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@ApiModel("CountTempPostsResponse")
+public class CountTempPostsResponse extends BaseResponseBody {
+
+    @ApiModelProperty(name = "임시 저장 게시글 개수")
+    int count;
+
+    public static CountTempPostsResponse of(int count, Integer statusCode, String message) {
+        CountTempPostsResponse res = new CountTempPostsResponse();
+        res.setCount(count);
+        res.setStatusCode(statusCode);
+        res.setMessage(message);
+        return res;
+    }
+}

--- a/backend/prologue/src/main/java/com/b208/prologue/api/service/TempPostService.java
+++ b/backend/prologue/src/main/java/com/b208/prologue/api/service/TempPostService.java
@@ -10,4 +10,5 @@ public interface TempPostService {
     Long saveTempPost(final SaveTempPostRequest saveTempPostRequest) throws Exception;
     void modifyTempPost(final ModifyTempPostRequest modifyTempPostRequest) throws Exception;
     void deleteTempPost(final String githubId, final Long tempPostId) throws Exception;
+    int countTempPosts(final String githubId) throws Exception;
 }

--- a/backend/prologue/src/main/java/com/b208/prologue/api/service/TempPostServiceImpl.java
+++ b/backend/prologue/src/main/java/com/b208/prologue/api/service/TempPostServiceImpl.java
@@ -75,5 +75,10 @@ public class TempPostServiceImpl implements TempPostService {
     public void deleteTempPost(final String githubId, final Long tempPostId) throws Exception {
         tempPostRepository.deleteByTempPostIdAndGithubId(tempPostId, githubId);
     }
+
+    @Override
+    public int countTempPosts(final String githubId) throws Exception {
+        return tempPostRepository.countByGithubId(githubId);
+    }
 }
 

--- a/backend/prologue/src/test/java/com/b208/prologue/tempPost/TempPostControllerTest.java
+++ b/backend/prologue/src/test/java/com/b208/prologue/tempPost/TempPostControllerTest.java
@@ -255,4 +255,38 @@ class TempPostControllerTest {
         }
     }
 
+    @Nested
+    class 임시저장게시글_수_조회 {
+
+        @Test
+        void 실패() throws Exception {
+            //given
+            doThrow(new Exception()).when(tempPostService).countTempPosts(githubId);
+
+            //when
+            final ResultActions resultActions = mockMvc.perform(
+                    MockMvcRequestBuilders.get(url + "/count")
+                            .param("githubId", githubId)
+            );
+
+            //then
+            resultActions.andExpect(status().isBadRequest());
+        }
+
+        @Test
+        void 성공() throws Exception {
+            //given
+            doReturn(127).when(tempPostService).countTempPosts(githubId);
+
+            //when
+            final ResultActions resultActions = mockMvc.perform(
+                    MockMvcRequestBuilders.get(url + "/count")
+                            .param("githubId", githubId)
+            );
+
+            //then
+            resultActions.andExpect(status().isOk());
+        }
+    }
+
 }

--- a/backend/prologue/src/test/java/com/b208/prologue/tempPost/TempPostRepositoryTest.java
+++ b/backend/prologue/src/test/java/com/b208/prologue/tempPost/TempPostRepositoryTest.java
@@ -66,4 +66,37 @@ class TempPostRepositoryTest {
         assertThat(tempPost).isNull();
     }
 
+    @Nested
+    class 임시저장게시글_수_조회 {
+        @Test
+        void 임시저장게시글없음() {
+            //given
+
+            //when
+            final int count = tempPostRepository.countByGithubId(githubId);
+
+            //then
+            assertThat(count).isZero();
+        }
+
+        @Test
+        void 임시저장게시글있음_2개() {
+            //given
+            tempPostRepository.save(TempPost.builder()
+                    .title("abc")
+                    .githubId(githubId)
+                    .build());
+            tempPostRepository.save(TempPost.builder()
+                    .title("123")
+                    .githubId(githubId)
+                    .build());
+
+            //when
+            final int count = tempPostRepository.countByGithubId(githubId);
+
+            //then
+            assertThat(count).isEqualTo(2);
+        }
+    }
+
 }

--- a/backend/prologue/src/test/java/com/b208/prologue/tempPost/TempPostServiceTest.java
+++ b/backend/prologue/src/test/java/com/b208/prologue/tempPost/TempPostServiceTest.java
@@ -140,4 +140,15 @@ class TempPostServiceTest {
         verify(tempPostRepository, times(1)).deleteByTempPostIdAndGithubId(any(Long.class), any(String.class));
     }
 
+    @Test
+    void 임시저장게시글_수_조회() throws Exception {
+        //given
+        doReturn(3).when(tempPostRepository).countByGithubId(any(String.class));
+
+        //when
+        int count = tempPostService.countTempPosts(githubId);
+
+        //then
+        assertThat(count).isEqualTo(3);
+    }
 }


### PR DESCRIPTION
close #22 

- 임시 저장한 게시글의 수를 조회하기 위한 레포지토리, 서비스, 컨트롤러 단의 테스트 코드와 프로덕션 코드를 작성했습니다.