### PR TITLE
[BE] 임시 저장 게시글 목록 조회 API 작성하기

### DIFF
--- a/backend/prologue/src/main/java/com/b208/prologue/api/controller/TempPostController.java
+++ b/backend/prologue/src/main/java/com/b208/prologue/api/controller/TempPostController.java
@@ -2,10 +2,7 @@ package com.b208.prologue.api.controller;
 
 import com.b208.prologue.api.request.ModifyTempPostRequest;
 import com.b208.prologue.api.request.SaveTempPostRequest;
-import com.b208.prologue.api.response.BaseResponseBody;
-import com.b208.prologue.api.response.GetTempPostResponse;
-import com.b208.prologue.api.response.CountTempPostsResponse;
-import com.b208.prologue.api.response.SaveTempPostResponse;
+import com.b208.prologue.api.response.*;
 import com.b208.prologue.api.service.TempPostService;
 import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiResponse;
@@ -15,6 +12,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 import javax.validation.Valid;
+import java.util.List;
 import java.util.Map;
 
 @CrossOrigin("*")
@@ -111,6 +109,23 @@ public class TempPostController {
         } catch (Exception e) {
             e.printStackTrace();
             return ResponseEntity.status(400).body(BaseResponseBody.of(400, "임시 저장 게시글 수 조회에 실패헸습니다."));
+        }
+    }
+
+    @GetMapping("/list")
+    @ApiOperation(value = "임시 저장 게시글 목록 조회", notes = "임시 저장 게시글 목록 조회")
+    @ApiResponses({
+            @ApiResponse(code = 200, message = "임시 저장 게시글 목록 조회 성공", response = GetTempPostsResponse.class),
+            @ApiResponse(code = 400, message = "임시 저장 게시글 목록 조회 실패", response = BaseResponseBody.class),
+            @ApiResponse(code = 500, message = "서버 오류", response = BaseResponseBody.class)
+    })
+    public ResponseEntity<? extends BaseResponseBody> getTempPosts(@RequestParam String githubId) {
+        try {
+            List<TempPostsResponse> tempPosts = tempPostService.getTempPosts(githubId);
+            return ResponseEntity.status(200).body(GetTempPostsResponse.of(tempPosts, 200, "임시 저장 게시글 목록 조회 성공했습니다."));
+        } catch (Exception e) {
+            e.printStackTrace();
+            return ResponseEntity.status(400).body(BaseResponseBody.of(400, "임시 저장 게시글 목록 조회에 실패헸습니다."));
         }
     }
 }

--- a/backend/prologue/src/main/java/com/b208/prologue/api/entity/TempPost.java
+++ b/backend/prologue/src/main/java/com/b208/prologue/api/entity/TempPost.java
@@ -29,7 +29,7 @@ public class TempPost {
     @Column
     private String title;
 
-    @Column
+    @Column(length = 1000)
     private String description;
 
     @Column
@@ -38,7 +38,7 @@ public class TempPost {
     @ElementCollection(fetch = FetchType.LAZY)
     private List<String> tags;
 
-    @Column
+    @Column(length = 10000)
     private String content;
 
     @CreatedDate

--- a/backend/prologue/src/main/java/com/b208/prologue/api/repository/TempPostRepository.java
+++ b/backend/prologue/src/main/java/com/b208/prologue/api/repository/TempPostRepository.java
@@ -4,9 +4,12 @@ import com.b208.prologue.api.entity.TempPost;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
+
 @Repository
 public interface TempPostRepository extends JpaRepository<TempPost, Long> {
     TempPost findByTempPostIdAndGithubId(final Long tempPostId, final String githubId);
     void deleteByTempPostIdAndGithubId(final Long tempPostId, final String githubId);
     int countByGithubId(final String githubId);
+    List<TempPost> findAllByGithubId(final String githubId);
 }

--- a/backend/prologue/src/main/java/com/b208/prologue/api/response/GetTempPostsResponse.java
+++ b/backend/prologue/src/main/java/com/b208/prologue/api/response/GetTempPostsResponse.java
@@ -1,0 +1,25 @@
+package com.b208.prologue.api.response;
+
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.util.List;
+
+@Getter
+@Setter
+@ApiModel("GetTempPostsResponse")
+public class GetTempPostsResponse extends BaseResponseBody {
+
+    @ApiModelProperty(name = "임시 저장 게시글 목록")
+    List<TempPostsResponse> data;
+
+    public static GetTempPostsResponse of(List<TempPostsResponse> data, Integer statusCode, String message) {
+        GetTempPostsResponse res = new GetTempPostsResponse();
+        res.setData(data);
+        res.setStatusCode(statusCode);
+        res.setMessage(message);
+        return res;
+    }
+}

--- a/backend/prologue/src/main/java/com/b208/prologue/api/response/TempPostsResponse.java
+++ b/backend/prologue/src/main/java/com/b208/prologue/api/response/TempPostsResponse.java
@@ -1,0 +1,17 @@
+package com.b208.prologue.api.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class TempPostsResponse {
+    Long tempPostId;
+    String title;
+    String summary;
+    String updatedAt;
+}

--- a/backend/prologue/src/main/java/com/b208/prologue/api/service/TempPostService.java
+++ b/backend/prologue/src/main/java/com/b208/prologue/api/service/TempPostService.java
@@ -2,7 +2,9 @@ package com.b208.prologue.api.service;
 
 import com.b208.prologue.api.request.ModifyTempPostRequest;
 import com.b208.prologue.api.request.SaveTempPostRequest;
+import com.b208.prologue.api.response.TempPostsResponse;
 
+import java.util.List;
 import java.util.Map;
 
 public interface TempPostService {
@@ -11,4 +13,5 @@ public interface TempPostService {
     void modifyTempPost(final ModifyTempPostRequest modifyTempPostRequest) throws Exception;
     void deleteTempPost(final String githubId, final Long tempPostId) throws Exception;
     int countTempPosts(final String githubId) throws Exception;
+    List<TempPostsResponse> getTempPosts(final String githubId) throws Exception;
 }

--- a/backend/prologue/src/main/java/com/b208/prologue/api/service/TempPostServiceImpl.java
+++ b/backend/prologue/src/main/java/com/b208/prologue/api/service/TempPostServiceImpl.java
@@ -5,11 +5,14 @@ import com.b208.prologue.api.exception.TempPostException;
 import com.b208.prologue.api.repository.TempPostRepository;
 import com.b208.prologue.api.request.ModifyTempPostRequest;
 import com.b208.prologue.api.request.SaveTempPostRequest;
+import com.b208.prologue.api.response.TempPostsResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 @Service
@@ -79,6 +82,21 @@ public class TempPostServiceImpl implements TempPostService {
     @Override
     public int countTempPosts(final String githubId) throws Exception {
         return tempPostRepository.countByGithubId(githubId);
+    }
+
+    @Override
+    public List<TempPostsResponse> getTempPosts(final String githubId) throws Exception {
+        List<TempPost> tempPostList = tempPostRepository.findAllByGithubId(githubId);
+        List<TempPostsResponse> tempPosts = new ArrayList<>();
+        for (TempPost tempPost : tempPostList) {
+            tempPosts.add(TempPostsResponse.builder()
+                    .tempPostId(tempPost.getTempPostId())
+                    .title(tempPost.getTitle())
+                    .summary((tempPost.getContent() == null || tempPost.getContent().length() < 150) ? tempPost.getContent() : tempPost.getContent().substring(0, 150))
+                    .updatedAt(String.valueOf(tempPost.getUpdateTime()))
+                    .build());
+        }
+        return tempPosts;
     }
 }
 

--- a/backend/prologue/src/test/java/com/b208/prologue/tempPost/TempPostControllerTest.java
+++ b/backend/prologue/src/test/java/com/b208/prologue/tempPost/TempPostControllerTest.java
@@ -4,6 +4,7 @@ import com.b208.prologue.api.controller.TempPostController;
 import com.b208.prologue.api.exception.TempPostException;
 import com.b208.prologue.api.request.ModifyTempPostRequest;
 import com.b208.prologue.api.request.SaveTempPostRequest;
+import com.b208.prologue.api.response.TempPostsResponse;
 import com.b208.prologue.api.service.TempPostServiceImpl;
 import com.google.gson.Gson;
 import org.junit.jupiter.api.BeforeEach;
@@ -19,7 +20,9 @@ import org.springframework.test.web.servlet.ResultActions;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 
+import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.doThrow;
@@ -281,6 +284,41 @@ class TempPostControllerTest {
             //when
             final ResultActions resultActions = mockMvc.perform(
                     MockMvcRequestBuilders.get(url + "/count")
+                            .param("githubId", githubId)
+            );
+
+            //then
+            resultActions.andExpect(status().isOk());
+        }
+    }
+
+    @Nested
+    class 임시저장게시글_목록_조회 {
+
+        @Test
+        void 실패() throws Exception {
+            //given
+            doThrow(new Exception()).when(tempPostService).getTempPosts(githubId);
+
+            //when
+            final ResultActions resultActions = mockMvc.perform(
+                    MockMvcRequestBuilders.get(url + "/list")
+                            .param("githubId", githubId)
+            );
+
+            //then
+            resultActions.andExpect(status().isBadRequest());
+        }
+
+        @Test
+        void 성공() throws Exception {
+            //given
+            List<TempPostsResponse> tempPosts = new ArrayList<>();
+            doReturn(tempPosts).when(tempPostService).getTempPosts(githubId);
+
+            //when
+            final ResultActions resultActions = mockMvc.perform(
+                    MockMvcRequestBuilders.get(url + "/list")
                             .param("githubId", githubId)
             );
 

--- a/backend/prologue/src/test/java/com/b208/prologue/tempPost/TempPostRepositoryTest.java
+++ b/backend/prologue/src/test/java/com/b208/prologue/tempPost/TempPostRepositoryTest.java
@@ -8,6 +8,8 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 
+import java.util.List;
+
 import static org.assertj.core.api.Assertions.assertThat;
 
 @DataJpaTest
@@ -96,6 +98,39 @@ class TempPostRepositoryTest {
 
             //then
             assertThat(count).isEqualTo(2);
+        }
+    }
+
+    @Nested
+    class 임시저장게시글_목록_조회 {
+        @Test
+        void 임시저장게시글없음() {
+            //given
+
+            //when
+            final List<TempPost> list = tempPostRepository.findAllByGithubId(githubId);
+
+            //then
+            assertThat(list).isNotNull().isEmpty();
+        }
+
+        @Test
+        void 임시저장게시글있음_2개() {
+            //given
+            tempPostRepository.save(TempPost.builder()
+                    .title("abc")
+                    .githubId(githubId)
+                    .build());
+            tempPostRepository.save(TempPost.builder()
+                    .title("123")
+                    .githubId(githubId)
+                    .build());
+
+            //when
+            final List<TempPost> list = tempPostRepository.findAllByGithubId(githubId);
+
+            //then
+            assertThat(list).hasSize(2);
         }
     }
 

--- a/backend/prologue/src/test/java/com/b208/prologue/tempPost/TempPostServiceTest.java
+++ b/backend/prologue/src/test/java/com/b208/prologue/tempPost/TempPostServiceTest.java
@@ -5,6 +5,7 @@ import com.b208.prologue.api.exception.TempPostException;
 import com.b208.prologue.api.repository.TempPostRepository;
 import com.b208.prologue.api.request.ModifyTempPostRequest;
 import com.b208.prologue.api.request.SaveTempPostRequest;
+import com.b208.prologue.api.response.TempPostsResponse;
 import com.b208.prologue.api.service.TempPostServiceImpl;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -13,6 +14,8 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -150,5 +153,26 @@ class TempPostServiceTest {
 
         //then
         assertThat(count).isEqualTo(3);
+    }
+
+    @Test
+    void 임시저장게시글_목록_조회() throws Exception {
+        //given
+        final List<TempPost> tempPostList = new ArrayList<>();
+        tempPostList.add(TempPost.builder()
+                .title("abc")
+                .githubId(githubId)
+                .build());
+        tempPostList.add(TempPost.builder()
+                .title("123")
+                .githubId(githubId)
+                .build());
+        doReturn(tempPostList).when(tempPostRepository).findAllByGithubId(any(String.class));
+
+        //when
+        List<TempPostsResponse> list = tempPostService.getTempPosts(githubId);
+
+        //then
+        assertThat(list).hasSize(2);
     }
 }


### PR DESCRIPTION
close #24 

- 임시 저장 게시글 목록을 조회하기 위한 레포지토리, 서비스, 컨트롤러 단의 테스트 코드와 프로덕션 코드를 작성했습니다.
- 임시 저장 게시글의 설명과 내용 부분의 글자 수의 제한값을 늘렸습니다.