### PR TITLE
[BE] 게시글 자동 저장 API 작성하기

### DIFF
--- a/backend/prologue/src/main/java/com/b208/prologue/api/controller/AutoSavePostController.java
+++ b/backend/prologue/src/main/java/com/b208/prologue/api/controller/AutoSavePostController.java
@@ -1,0 +1,39 @@
+package com.b208.prologue.api.controller;
+
+import com.b208.prologue.api.request.AutoSavePostRequest;
+import com.b208.prologue.api.response.BaseResponseBody;
+import com.b208.prologue.api.service.AutoSavePostService;
+import io.swagger.annotations.ApiOperation;
+import io.swagger.annotations.ApiResponse;
+import io.swagger.annotations.ApiResponses;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import javax.validation.Valid;
+
+@CrossOrigin("*")
+@RestController
+@RequestMapping("/api/auto-posts")
+@RequiredArgsConstructor
+public class AutoSavePostController {
+
+    private final AutoSavePostService autoSavePostService;
+
+    @PostMapping("")
+    @ApiOperation(value = "게시글 자동 저장", notes = "게시글을 자동 저장한다.")
+    @ApiResponses({
+            @ApiResponse(code = 200, message = "게시글 자동 저장 성공", response = BaseResponseBody.class),
+            @ApiResponse(code = 400, message = "게시글 자동 저장 실패", response = BaseResponseBody.class),
+            @ApiResponse(code = 500, message = "서버 오류", response = BaseResponseBody.class)
+    })
+    public ResponseEntity<? extends BaseResponseBody> autoSavePost(@Valid @RequestBody final AutoSavePostRequest autoSavePostRequest) {
+        try {
+            autoSavePostService.autoSavePost(autoSavePostRequest);
+            return ResponseEntity.status(200).body(BaseResponseBody.of(200, "게시글 자동 저장에 성공했습니다."));
+        } catch (Exception e) {
+            e.printStackTrace();
+            return ResponseEntity.status(400).body(BaseResponseBody.of(400, "게시글 자동 저장에 실패헸습니다."));
+        }
+    }
+}

--- a/backend/prologue/src/main/java/com/b208/prologue/api/entity/AutoSavePost.java
+++ b/backend/prologue/src/main/java/com/b208/prologue/api/entity/AutoSavePost.java
@@ -1,0 +1,42 @@
+package com.b208.prologue.api.entity;
+
+import lombok.*;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import javax.persistence.*;
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Entity
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@EntityListeners(AuditingEntityListener.class)
+@Table(name = "auto_save_post")
+public class AutoSavePost {
+
+    @Id
+    @Column(name = "github_id")
+    private String githubId;
+
+    @Column
+    private String title;
+
+    @Column(length = 1000)
+    private String description;
+
+    @Column
+    private String category;
+
+    @ElementCollection(fetch = FetchType.LAZY)
+    private List<String> tags;
+
+    @Column(length = 10000)
+    private String content;
+
+    @LastModifiedDate
+    @Column(nullable = false)
+    private LocalDateTime updateTime;
+}

--- a/backend/prologue/src/main/java/com/b208/prologue/api/repository/AutoSavePostRepository.java
+++ b/backend/prologue/src/main/java/com/b208/prologue/api/repository/AutoSavePostRepository.java
@@ -1,0 +1,10 @@
+package com.b208.prologue.api.repository;
+
+import com.b208.prologue.api.entity.AutoSavePost;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface AutoSavePostRepository extends JpaRepository<AutoSavePost, String> {
+    AutoSavePost findByGithubId(final String githubId);
+}

--- a/backend/prologue/src/main/java/com/b208/prologue/api/request/AutoSavePostRequest.java
+++ b/backend/prologue/src/main/java/com/b208/prologue/api/request/AutoSavePostRequest.java
@@ -1,0 +1,36 @@
+package com.b208.prologue.api.request;
+
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+import lombok.*;
+
+import javax.validation.constraints.NotBlank;
+import java.util.List;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Data
+@ApiModel("AutoSavePostRequest")
+public class AutoSavePostRequest {
+
+    @NotBlank
+    @ApiModelProperty(name = "깃허브 아이디", example = "test1234", required = true)
+    String githubId;
+
+    @ApiModelProperty(name = "게시글 제목", example = "게시글 제목", required = true)
+    String title;
+
+    @ApiModelProperty(name = "게시글 설명", example = "게시글 설명", required = true)
+    String description;
+
+    @ApiModelProperty(name = "카테고리", example = "카테고리", required = true)
+    String category;
+
+    @ApiModelProperty(name = "태그 리스트", example = "태그 리스트", required = true)
+    List<String> tags;
+
+    @ApiModelProperty(name = "게시글 내용", example = "게시글 내용", required = true)
+    String content;
+}

--- a/backend/prologue/src/main/java/com/b208/prologue/api/service/AutoSavePostService.java
+++ b/backend/prologue/src/main/java/com/b208/prologue/api/service/AutoSavePostService.java
@@ -1,0 +1,7 @@
+package com.b208.prologue.api.service;
+
+import com.b208.prologue.api.request.AutoSavePostRequest;
+
+public interface AutoSavePostService {
+    void autoSavePost(final AutoSavePostRequest autoSavePostRequest) throws Exception;
+}

--- a/backend/prologue/src/main/java/com/b208/prologue/api/service/AutoSavePostServiceImpl.java
+++ b/backend/prologue/src/main/java/com/b208/prologue/api/service/AutoSavePostServiceImpl.java
@@ -1,0 +1,28 @@
+package com.b208.prologue.api.service;
+
+import com.b208.prologue.api.entity.AutoSavePost;
+import com.b208.prologue.api.repository.AutoSavePostRepository;
+import com.b208.prologue.api.request.AutoSavePostRequest;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class AutoSavePostServiceImpl implements AutoSavePostService {
+
+    private final AutoSavePostRepository autoSavePostRepository;
+
+    @Override
+    public void autoSavePost(final AutoSavePostRequest autoSavePostRequest) throws Exception {
+        final AutoSavePost autoSavePost = AutoSavePost.builder()
+                .githubId(autoSavePostRequest.getGithubId())
+                .title(autoSavePostRequest.getTitle())
+                .description(autoSavePostRequest.getDescription())
+                .category(autoSavePostRequest.getCategory())
+                .tags(autoSavePostRequest.getTags())
+                .content(autoSavePostRequest.getContent())
+                .build();
+        autoSavePostRepository.save(autoSavePost);
+    }
+}
+

--- a/backend/prologue/src/test/java/com/b208/prologue/autoSavePost/AutoSavePostControllerTest.java
+++ b/backend/prologue/src/test/java/com/b208/prologue/autoSavePost/AutoSavePostControllerTest.java
@@ -1,0 +1,102 @@
+package com.b208.prologue.autoSavePost;
+
+import com.b208.prologue.api.controller.AutoSavePostController;
+import com.b208.prologue.api.request.AutoSavePostRequest;
+import com.b208.prologue.api.service.AutoSavePostServiceImpl;
+import com.google.gson.Gson;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+import static org.mockito.Mockito.doThrow;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@ExtendWith(MockitoExtension.class)
+class AutoSavePostControllerTest {
+
+    @InjectMocks
+    private AutoSavePostController autoSavePostController;
+
+    @Mock
+    private AutoSavePostServiceImpl autoSavePostService;
+
+    private static final String githubId = "test**";
+    private static final String url = "/api/auto-posts";
+
+    private MockMvc mockMvc;
+    private Gson gson;
+
+    @BeforeEach
+    void init() {
+        gson = new Gson();
+        mockMvc = MockMvcBuilders.standaloneSetup(autoSavePostController)
+                .build();
+    }
+
+    @Nested
+    class 게시글_자동저장 {
+        final AutoSavePostRequest autoSavePostRequest = AutoSavePostRequest.builder()
+                .githubId(githubId)
+                .title("abc")
+                .build();
+
+        @Test
+        void 실패_깃허브ID없음() throws Exception {
+            //given
+            final AutoSavePostRequest autoSavePostRequest = AutoSavePostRequest.builder()
+                    .title("abc")
+                    .build();
+
+            //when
+            final ResultActions resultActions = mockMvc.perform(
+                    MockMvcRequestBuilders.post(url)
+                            .content(gson.toJson(autoSavePostRequest))
+                            .contentType(MediaType.APPLICATION_JSON)
+            );
+
+            //then
+            resultActions.andExpect(status().isBadRequest());
+        }
+
+        @Test
+        void 실패() throws Exception {
+            //given
+            doThrow(new Exception()).when(autoSavePostService).autoSavePost(autoSavePostRequest);
+
+            //when
+            final ResultActions resultActions = mockMvc.perform(
+                    MockMvcRequestBuilders.post(url)
+                            .content(gson.toJson(autoSavePostRequest))
+                            .contentType(MediaType.APPLICATION_JSON)
+            );
+
+            //then
+            resultActions.andExpect(status().isBadRequest());
+        }
+
+        @Test
+        void 성공() throws Exception {
+            //given
+
+            //when
+            final ResultActions resultActions = mockMvc.perform(
+                    MockMvcRequestBuilders.post(url)
+                            .content(gson.toJson(autoSavePostRequest))
+                            .contentType(MediaType.APPLICATION_JSON)
+            );
+
+            //then
+            resultActions.andExpect(status().isOk());
+        }
+    }
+
+}

--- a/backend/prologue/src/test/java/com/b208/prologue/autoSavePost/AutoSavePostRepositoryTest.java
+++ b/backend/prologue/src/test/java/com/b208/prologue/autoSavePost/AutoSavePostRepositoryTest.java
@@ -1,0 +1,62 @@
+package com.b208.prologue.autoSavePost;
+
+import com.b208.prologue.api.entity.AutoSavePost;
+import com.b208.prologue.api.repository.AutoSavePostRepository;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DataJpaTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+class AutoSavePostRepositoryTest {
+
+    @Autowired
+    private AutoSavePostRepository autoSavePostRepository;
+
+    private static final String githubId = "test**";
+
+    @Nested
+    class 자동저장게시글_생성 {
+
+        @Test
+        void 자동저장_처음생성() {
+            //given
+            autoSavePostRepository.save(AutoSavePost.builder()
+                    .title("abc")
+                    .githubId(githubId)
+                    .build());
+
+            //when
+            final AutoSavePost autoSavePost = autoSavePostRepository.findByGithubId(githubId);
+
+            //then
+            assertThat(autoSavePost).isNotNull();
+            assertThat(autoSavePost.getTitle()).isEqualTo("abc");
+        }
+
+        @Test
+        void 자동저장_덮어쓰기() {
+            //given
+            autoSavePostRepository.save(AutoSavePost.builder()
+                    .title("abc")
+                    .githubId(githubId)
+                    .build());
+            autoSavePostRepository.save(AutoSavePost.builder()
+                    .title("123")
+                    .githubId(githubId)
+                    .build());
+
+            //when
+            final AutoSavePost autoSavePost = autoSavePostRepository.findByGithubId(githubId);
+
+            //then
+            assertThat(autoSavePost).isNotNull();
+            assertThat(autoSavePost.getTitle()).isEqualTo("123");
+        }
+    }
+
+}

--- a/backend/prologue/src/test/java/com/b208/prologue/autoSavePost/AutoSavePostServiceTest.java
+++ b/backend/prologue/src/test/java/com/b208/prologue/autoSavePost/AutoSavePostServiceTest.java
@@ -1,0 +1,42 @@
+package com.b208.prologue.autoSavePost;
+
+import com.b208.prologue.api.entity.AutoSavePost;
+import com.b208.prologue.api.repository.AutoSavePostRepository;
+import com.b208.prologue.api.request.AutoSavePostRequest;
+import com.b208.prologue.api.service.AutoSavePostServiceImpl;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class AutoSavePostServiceTest {
+
+    @InjectMocks
+    private AutoSavePostServiceImpl autoSavePostService;
+
+    @Mock
+    private AutoSavePostRepository autoSavePostRepository;
+
+    private static final String githubId = "test**";
+
+    @Test
+    void 게시글_자동저장() throws Exception {
+        //given
+        final AutoSavePostRequest autoSavePostRequest = AutoSavePostRequest.builder()
+                .githubId(githubId)
+                .title("abc")
+                .build();
+
+        //when
+        autoSavePostService.autoSavePost(autoSavePostRequest);
+
+        //then
+
+        //verify
+        verify(autoSavePostRepository, times(1)).save(any(AutoSavePost.class));
+    }
+}


### PR DESCRIPTION
close #27 

- 자동 저장 게시글 엔티티를 정의했습니다.
- 게시글을 자동 저장하기 위한 서비스, 컨트롤러 단의 테스트 코드와 프로덕션 코드를 작성했습니다.
