### PR TITLE
[BE] 자동 저장 게시글 조회 API 작성하기

### DIFF
--- a/backend/prologue/src/main/java/com/b208/prologue/api/controller/AutoSavePostController.java
+++ b/backend/prologue/src/main/java/com/b208/prologue/api/controller/AutoSavePostController.java
@@ -3,6 +3,7 @@ package com.b208.prologue.api.controller;
 import com.b208.prologue.api.request.AutoSavePostRequest;
 import com.b208.prologue.api.response.BaseResponseBody;
 import com.b208.prologue.api.response.CheckAutoSavePostsResponse;
+import com.b208.prologue.api.response.GetAutoSavePostResponse;
 import com.b208.prologue.api.service.AutoSavePostService;
 import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiResponse;
@@ -12,10 +13,11 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 import javax.validation.Valid;
+import java.util.Map;
 
 @CrossOrigin("*")
 @RestController
-@RequestMapping("/api/auto-posts")
+@RequestMapping("/api/auto-post")
 @RequiredArgsConstructor
 public class AutoSavePostController {
 
@@ -35,6 +37,23 @@ public class AutoSavePostController {
         } catch (Exception e) {
             e.printStackTrace();
             return ResponseEntity.status(400).body(BaseResponseBody.of(400, "게시글 자동 저장에 실패헸습니다."));
+        }
+    }
+
+    @GetMapping("")
+    @ApiOperation(value = "자동 저장 게시글 조회", notes = "자동 저장 게시글 조회하기")
+    @ApiResponses({
+            @ApiResponse(code = 200, message = "자동 저장 게시글 조회 성공", response = GetAutoSavePostResponse.class),
+            @ApiResponse(code = 400, message = "자동 저장 게시글 조회 실패", response = BaseResponseBody.class),
+            @ApiResponse(code = 500, message = "서버 오류", response = BaseResponseBody.class)
+    })
+    public ResponseEntity<? extends BaseResponseBody> getAutoSavePost(@RequestParam String githubId) {
+        try {
+            final Map<String, Object> result = autoSavePostService.getAutoSavePost(githubId);
+            return ResponseEntity.status(200).body(GetAutoSavePostResponse.of(result, 200, "자동 저장 게시글 조회에 성공했습니다."));
+        } catch (Exception e) {
+            e.printStackTrace();
+            return ResponseEntity.status(400).body(BaseResponseBody.of(400, "자동 저장 게시글 조회에 실패헸습니다."));
         }
     }
 

--- a/backend/prologue/src/main/java/com/b208/prologue/api/response/GetAutoSavePostResponse.java
+++ b/backend/prologue/src/main/java/com/b208/prologue/api/response/GetAutoSavePostResponse.java
@@ -1,0 +1,47 @@
+package com.b208.prologue.api.response;
+
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Map;
+
+@Getter
+@Setter
+@ApiModel("GetAutoSavePostResponse")
+public class GetAutoSavePostResponse extends BaseResponseBody {
+
+    @ApiModelProperty(name = "자동 저장 게시글 제목")
+    String title;
+
+    @ApiModelProperty(name = "자동 저장 게시글 설명")
+    String description;
+
+    @ApiModelProperty(name = "자동 저장 게시글 카테고리")
+    String category;
+
+    @ApiModelProperty(name = "자동 저장 게시글 태그")
+    List<String> tags;
+
+    @ApiModelProperty(name = "자동 저장 게시글 내용")
+    String content;
+
+    @ApiModelProperty(name = "게시글 자동 저장 시간")
+    LocalDateTime updatedAt;
+
+    public static GetAutoSavePostResponse of(Map<String, Object> result, Integer statusCode, String message) {
+        GetAutoSavePostResponse res = new GetAutoSavePostResponse();
+        res.setTitle((String) result.get("title"));
+        res.setDescription((String) result.get("description"));
+        res.setCategory((String) result.get("category"));
+        res.setTags((List<String>) result.get("tags"));
+        res.setContent((String) result.get("content"));
+        res.setUpdatedAt((LocalDateTime) result.get("updatedAt"));
+        res.setStatusCode(statusCode);
+        res.setMessage(message);
+        return res;
+    }
+}

--- a/backend/prologue/src/main/java/com/b208/prologue/api/service/AutoSavePostService.java
+++ b/backend/prologue/src/main/java/com/b208/prologue/api/service/AutoSavePostService.java
@@ -3,8 +3,11 @@ package com.b208.prologue.api.service;
 import com.b208.prologue.api.exception.AutoSavePostException;
 import com.b208.prologue.api.request.AutoSavePostRequest;
 
+import java.util.Map;
+
 public interface AutoSavePostService {
     void autoSavePost(final AutoSavePostRequest autoSavePostRequest) throws Exception;
     boolean checkAutoSavePost(final String githubId) throws Exception;
     String getUpdatedTime(final String githubId) throws AutoSavePostException;
+    Map<String, Object> getAutoSavePost(final String githubId) throws AutoSavePostException;
 }

--- a/backend/prologue/src/main/java/com/b208/prologue/api/service/AutoSavePostServiceImpl.java
+++ b/backend/prologue/src/main/java/com/b208/prologue/api/service/AutoSavePostServiceImpl.java
@@ -7,6 +7,9 @@ import com.b208.prologue.api.request.AutoSavePostRequest;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
+import java.util.HashMap;
+import java.util.Map;
+
 @Service
 @RequiredArgsConstructor
 public class AutoSavePostServiceImpl implements AutoSavePostService {
@@ -37,5 +40,21 @@ public class AutoSavePostServiceImpl implements AutoSavePostService {
         if (autoSavePost == null) throw new AutoSavePostException();
         return String.valueOf(autoSavePost.getUpdateTime());
     }
+
+    @Override
+    public Map<String, Object> getAutoSavePost(final String githubId) throws AutoSavePostException {
+        final AutoSavePost autoSavePost = autoSavePostRepository.findByGithubId(githubId);
+        if (autoSavePost == null) throw new AutoSavePostException();
+
+        Map<String, Object> result = new HashMap<>();
+        result.put("title", autoSavePost.getTitle());
+        result.put("description", autoSavePost.getDescription());
+        result.put("category", autoSavePost.getCategory());
+        result.put("tags", autoSavePost.getTags());
+        result.put("content", autoSavePost.getContent());
+        result.put("updatedAt", autoSavePost.getUpdateTime());
+        return result;
+    }
+
 }
 

--- a/backend/prologue/src/test/java/com/b208/prologue/autoSavePost/AutoSavePostControllerTest.java
+++ b/backend/prologue/src/test/java/com/b208/prologue/autoSavePost/AutoSavePostControllerTest.java
@@ -1,6 +1,7 @@
 package com.b208.prologue.autoSavePost;
 
 import com.b208.prologue.api.controller.AutoSavePostController;
+import com.b208.prologue.api.exception.AutoSavePostException;
 import com.b208.prologue.api.request.AutoSavePostRequest;
 import com.b208.prologue.api.service.AutoSavePostServiceImpl;
 import com.google.gson.Gson;
@@ -35,7 +36,7 @@ class AutoSavePostControllerTest {
     private AutoSavePostServiceImpl autoSavePostService;
 
     private static final String githubId = "test**";
-    private static final String url = "/api/auto-posts";
+    private static final String url = "/api/auto-post";
 
     private MockMvc mockMvc;
     private Gson gson;
@@ -97,6 +98,60 @@ class AutoSavePostControllerTest {
                     MockMvcRequestBuilders.post(url)
                             .content(gson.toJson(autoSavePostRequest))
                             .contentType(MediaType.APPLICATION_JSON)
+            );
+
+            //then
+            resultActions.andExpect(status().isOk());
+        }
+    }
+
+    @Nested
+    class 자동저장게시글_조회 {
+
+        @Test
+        void 실패_깃허브ID없음() throws Exception {
+            //given
+
+            //when
+            final ResultActions resultActions = mockMvc.perform(
+                    MockMvcRequestBuilders.get(url)
+            );
+
+            //then
+            resultActions.andExpect(status().isBadRequest());
+        }
+
+        @Test
+        void 실패() throws Exception {
+            //given
+            doThrow(new AutoSavePostException()).when(autoSavePostService).getAutoSavePost(githubId);
+
+            //when
+            final ResultActions resultActions = mockMvc.perform(
+                    MockMvcRequestBuilders.get(url)
+                            .param("githubId", githubId)
+            );
+
+            //then
+            resultActions.andExpect(status().isBadRequest());
+        }
+
+        @Test
+        void 성공() throws Exception {
+            //given
+            final Map<String, Object> result = new HashMap<>();
+            result.put("title", "제목");
+            result.put("description", "설명");
+            result.put("category", "카테고리");
+            result.put("tags", null);
+            result.put("content", "내용");
+            result.put("updatedAt", LocalDateTime.now());
+            doReturn(result).when(autoSavePostService).getAutoSavePost(githubId);
+
+            //when
+            final ResultActions resultActions = mockMvc.perform(
+                    MockMvcRequestBuilders.get(url)
+                            .param("githubId", githubId)
             );
 
             //then

--- a/backend/prologue/src/test/java/com/b208/prologue/autoSavePost/AutoSavePostServiceTest.java
+++ b/backend/prologue/src/test/java/com/b208/prologue/autoSavePost/AutoSavePostServiceTest.java
@@ -13,6 +13,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.time.LocalDateTime;
+import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -62,6 +63,41 @@ class AutoSavePostServiceTest {
     }
 
     @Nested
+    class 자동저장게시글_조회 {
+        @Test
+        void 자동저장게시글_존재안함() throws Exception {
+            //given
+            doReturn(null).when(autoSavePostRepository).findByGithubId(githubId);
+
+            //when
+            assertThrows(AutoSavePostException.class, () -> autoSavePostService.getAutoSavePost(githubId));
+
+            //then
+
+            //verify
+            verify(autoSavePostRepository, times(1)).findByGithubId(any(String.class));
+        }
+
+        @Test
+        void 자동저장게시글_존재함() throws Exception {
+            //given
+            final AutoSavePost autoSavePost = AutoSavePost.builder()
+                    .githubId(githubId)
+                    .title("abc")
+                    .updateTime(LocalDateTime.now())
+                    .build();
+            doReturn(autoSavePost).when(autoSavePostRepository).findByGithubId(githubId);
+
+            //when
+            final Map<String, Object> result = autoSavePostService.getAutoSavePost(githubId);
+
+            //then
+            assertThat(result).isNotNull();
+            assertThat((String) result.get("title")).isEqualTo("abc");
+        }
+    }
+
+    @Nested
     class 자동저장게시글_시간조회 {
         @Test
         void 자동저장게시글_존재안함() throws Exception {
@@ -69,7 +105,7 @@ class AutoSavePostServiceTest {
             doReturn(null).when(autoSavePostRepository).findByGithubId(githubId);
 
             //when
-            final AutoSavePostException result = assertThrows(AutoSavePostException.class, () -> autoSavePostService.getUpdatedTime(githubId));
+            assertThrows(AutoSavePostException.class, () -> autoSavePostService.getUpdatedTime(githubId));
 
             //then
 


### PR DESCRIPTION
close #31 

- 자동 저장 게시글을 조회하기 위한 서비스, 컨트롤러 단의 테스트 코드와 프로덕션 코드를 작성했습니다.
- uri를 수정했습니다. `/api/auto-posts` -> `/api/auto-post`