### PR TITLE
[BE] 게시글 작성 API 로직 수정

### DIFF
--- a/backend/prologue/src/main/java/com/b208/prologue/api/repository/AutoSavePostRepository.java
+++ b/backend/prologue/src/main/java/com/b208/prologue/api/repository/AutoSavePostRepository.java
@@ -8,4 +8,5 @@ import org.springframework.stereotype.Repository;
 public interface AutoSavePostRepository extends JpaRepository<AutoSavePost, String> {
     AutoSavePost findByGithubId(final String githubId);
     boolean existsByGithubId(final String githubId);
+    void deleteByGithubId(final String githubId);
 }

--- a/backend/prologue/src/main/java/com/b208/prologue/api/request/WriteDetailPostRequest.java
+++ b/backend/prologue/src/main/java/com/b208/prologue/api/request/WriteDetailPostRequest.java
@@ -34,4 +34,7 @@ public class WriteDetailPostRequest {
     @ApiModelProperty(name = "이미지 url, 상대경로", example = "이미지 url, 상대경로")
     List<ImageResponse> images;
 
+    @ApiModelProperty(name = "임시 저장 게시글 아이디", example = "0L")
+    Long tempPostId;
+
 }

--- a/backend/prologue/src/main/java/com/b208/prologue/api/service/AutoSavePostService.java
+++ b/backend/prologue/src/main/java/com/b208/prologue/api/service/AutoSavePostService.java
@@ -10,4 +10,5 @@ public interface AutoSavePostService {
     boolean checkAutoSavePost(final String githubId) throws Exception;
     String getUpdatedTime(final String githubId) throws AutoSavePostException;
     Map<String, Object> getAutoSavePost(final String githubId) throws AutoSavePostException;
+    void deleteAutoSavePost(final String githubId) throws Exception;
 }

--- a/backend/prologue/src/main/java/com/b208/prologue/api/service/AutoSavePostServiceImpl.java
+++ b/backend/prologue/src/main/java/com/b208/prologue/api/service/AutoSavePostServiceImpl.java
@@ -56,5 +56,10 @@ public class AutoSavePostServiceImpl implements AutoSavePostService {
         return result;
     }
 
+    @Override
+    public void deleteAutoSavePost(final String githubId) throws Exception {
+        autoSavePostRepository.deleteByGithubId(githubId);
+    }
+
 }
 

--- a/backend/prologue/src/test/java/com/b208/prologue/autoSavePost/AutoSavePostRepositoryTest.java
+++ b/backend/prologue/src/test/java/com/b208/prologue/autoSavePost/AutoSavePostRepositoryTest.java
@@ -89,4 +89,21 @@ class AutoSavePostRepositoryTest {
         }
     }
 
+
+    @Test
+    void 자동저장게시글_삭제() {
+        //given
+        autoSavePostRepository.save(AutoSavePost.builder()
+                .title("abc")
+                .githubId(githubId)
+                .build());
+
+        //when
+        autoSavePostRepository.deleteByGithubId(githubId);
+        final AutoSavePost autoSavePost = autoSavePostRepository.findByGithubId(githubId);
+
+        //then
+        assertThat(autoSavePost).isNull();
+    }
+
 }

--- a/backend/prologue/src/test/java/com/b208/prologue/autoSavePost/AutoSavePostServiceTest.java
+++ b/backend/prologue/src/test/java/com/b208/prologue/autoSavePost/AutoSavePostServiceTest.java
@@ -131,4 +131,17 @@ class AutoSavePostServiceTest {
         }
     }
 
+    @Test
+    void 자동저장게시글_삭제() throws Exception {
+        //given
+
+        //when
+        autoSavePostService.deleteAutoSavePost(githubId);
+
+        //then
+
+        //verify
+        verify(autoSavePostRepository, times(1)).deleteByGithubId(any(String.class));
+    }
+
 }


### PR DESCRIPTION
close #26 

- 임시 저장 게시글이 게시글로 업로드되면, 기존에 임시 저장되어있던 게시글을 삭제하는 로직을 추가했습니다.
- 게시글이 업로드되면, 자동 저장한 게시글을 삭제하는 로직을 추가했습니다.
- 자동 저장한 게시글을 삭제하기 위한 레포지토리, 서비스 단의 테스트 코드와 프로덕션 코드를 작성했습니다.