### PR TITLE
[BE] 임시 저장 게시글 관련 API 응답 수정

### DIFF
--- a/backend/prologue/src/main/java/com/b208/prologue/api/response/GetTempPostResponse.java
+++ b/backend/prologue/src/main/java/com/b208/prologue/api/response/GetTempPostResponse.java
@@ -5,6 +5,8 @@ import io.swagger.annotations.ApiModelProperty;
 import lombok.Getter;
 import lombok.Setter;
 
+import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Map;
 
 @Getter
@@ -12,12 +14,40 @@ import java.util.Map;
 @ApiModel("GetTempPostResponse")
 public class GetTempPostResponse extends BaseResponseBody {
 
-    @ApiModelProperty(name = "임시 저장 게시글 관련 정보")
-    Map<String, Object> result;
+    @ApiModelProperty(name = "임시 저장 게시글 아이디")
+    Long tempPostId;
 
-    public static GetTempPostResponse of(Map<String, Object> result, Integer statusCode, String message){
+    @ApiModelProperty(name = "임시 저장 게시글 제목")
+    String title;
+
+    @ApiModelProperty(name = "임시 저장 게시글 설명")
+    String description;
+
+    @ApiModelProperty(name = "임시 저장 게시글 카테고리")
+    String category;
+
+    @ApiModelProperty(name = "임시 저장 게시글 태그")
+    List<String> tags;
+
+    @ApiModelProperty(name = "임시 저장 게시글 내용")
+    String content;
+
+    @ApiModelProperty(name = "게시글 임시 저장 생성 시간")
+    LocalDateTime createdAt;
+
+    @ApiModelProperty(name = "게시글 임시 저장 변경 시간")
+    LocalDateTime updatedAt;
+
+    public static GetTempPostResponse of(Map<String, Object> result, Integer statusCode, String message) {
         GetTempPostResponse res = new GetTempPostResponse();
-        res.setResult(result);
+        res.setTempPostId((Long) result.get("tempPostId"));
+        res.setTitle((String) result.get("title"));
+        res.setDescription((String) result.get("description"));
+        res.setCategory((String) result.get("category"));
+        res.setTags((List<String>) result.get("tags"));
+        res.setContent((String) result.get("content"));
+        res.setCreatedAt((LocalDateTime) result.get("createdAt"));
+        res.setUpdatedAt((LocalDateTime) result.get("updatedAt"));
         res.setStatusCode(statusCode);
         res.setMessage(message);
         return res;

--- a/backend/prologue/src/main/java/com/b208/prologue/api/response/TempPostsResponse.java
+++ b/backend/prologue/src/main/java/com/b208/prologue/api/response/TempPostsResponse.java
@@ -5,6 +5,8 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.time.LocalDateTime;
+
 @Getter
 @NoArgsConstructor
 @AllArgsConstructor
@@ -13,5 +15,5 @@ public class TempPostsResponse {
     Long tempPostId;
     String title;
     String summary;
-    String updatedAt;
+    LocalDateTime updatedAt;
 }

--- a/backend/prologue/src/main/java/com/b208/prologue/api/service/TempPostServiceImpl.java
+++ b/backend/prologue/src/main/java/com/b208/prologue/api/service/TempPostServiceImpl.java
@@ -93,7 +93,7 @@ public class TempPostServiceImpl implements TempPostService {
                     .tempPostId(tempPost.getTempPostId())
                     .title(tempPost.getTitle())
                     .summary((tempPost.getContent() == null || tempPost.getContent().length() < 150) ? tempPost.getContent() : tempPost.getContent().substring(0, 150))
-                    .updatedAt(String.valueOf(tempPost.getUpdateTime()))
+                    .updatedAt(tempPost.getUpdateTime())
                     .build());
         }
         return tempPosts;


### PR DESCRIPTION
close #34 

- 임시 저장 게시글 목록 조회 시 시간 응답값 자료형을 `String`에서 `LocalDateTime`으로 변경했습니다.
- 임시 저장 게시글 조회 응답 형식을 `Map`을 분리해 각 데이터를 표시하도록 변경하였습니다.