### PR TITLE
[BE] 스프링 스케줄러 설정하기

### DIFF
--- a/backend/prologue/.gitignore
+++ b/backend/prologue/.gitignore
@@ -38,6 +38,7 @@ out/
 
 src/main/resources/application.properties
 src/main/resources/deploy.yaml
+src/test/resources/application.properties
 
 **/.DS_Store
 .DS_Store

--- a/backend/prologue/src/main/java/com/b208/prologue/PrologueApplication.java
+++ b/backend/prologue/src/main/java/com/b208/prologue/PrologueApplication.java
@@ -3,7 +3,9 @@ package com.b208.prologue;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
+@EnableScheduling
 @EnableJpaAuditing
 @SpringBootApplication
 public class PrologueApplication {

--- a/backend/prologue/src/main/java/com/b208/prologue/api/entity/AutoSavePost.java
+++ b/backend/prologue/src/main/java/com/b208/prologue/api/entity/AutoSavePost.java
@@ -24,7 +24,7 @@ public class AutoSavePost {
     @Column
     private String title;
 
-    @Column(length = 1000)
+    @Column(name = "representation", length = 1000)
     private String description;
 
     @Column

--- a/backend/prologue/src/main/java/com/b208/prologue/api/entity/AutoSavePost.java
+++ b/backend/prologue/src/main/java/com/b208/prologue/api/entity/AutoSavePost.java
@@ -1,5 +1,6 @@
 package com.b208.prologue.api.entity;
 
+import com.b208.prologue.common.StringListConverter;
 import lombok.*;
 import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
@@ -30,7 +31,8 @@ public class AutoSavePost {
     @Column
     private String category;
 
-    @ElementCollection(fetch = FetchType.LAZY)
+    @Convert(converter = StringListConverter.class)
+    @Column(length = 1000)
     private List<String> tags;
 
     @Column(length = 10000)

--- a/backend/prologue/src/main/java/com/b208/prologue/api/entity/TempPost.java
+++ b/backend/prologue/src/main/java/com/b208/prologue/api/entity/TempPost.java
@@ -29,7 +29,7 @@ public class TempPost {
     @Column
     private String title;
 
-    @Column(length = 1000)
+    @Column(name = "representation", length = 1000)
     private String description;
 
     @Column

--- a/backend/prologue/src/main/java/com/b208/prologue/api/entity/TempPost.java
+++ b/backend/prologue/src/main/java/com/b208/prologue/api/entity/TempPost.java
@@ -1,5 +1,6 @@
 package com.b208.prologue.api.entity;
 
+import com.b208.prologue.common.StringListConverter;
 import lombok.*;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
@@ -35,7 +36,8 @@ public class TempPost {
     @Column
     private String category;
 
-    @ElementCollection(fetch = FetchType.LAZY)
+    @Convert(converter = StringListConverter.class)
+    @Column(length = 1000)
     private List<String> tags;
 
     @Column(length = 10000)

--- a/backend/prologue/src/main/java/com/b208/prologue/api/repository/AutoSavePostRepository.java
+++ b/backend/prologue/src/main/java/com/b208/prologue/api/repository/AutoSavePostRepository.java
@@ -2,11 +2,19 @@ package com.b208.prologue.api.repository;
 
 import com.b208.prologue.api.entity.AutoSavePost;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
+
+import java.time.LocalDateTime;
 
 @Repository
 public interface AutoSavePostRepository extends JpaRepository<AutoSavePost, String> {
     AutoSavePost findByGithubId(final String githubId);
     boolean existsByGithubId(final String githubId);
     void deleteByGithubId(final String githubId);
+
+    @Modifying
+    @Query("delete from AutoSavePost a where a.updateTime < :target")
+    void deleteByUpdateTimeBefore(final LocalDateTime target);
 }

--- a/backend/prologue/src/main/java/com/b208/prologue/api/repository/TempPostRepository.java
+++ b/backend/prologue/src/main/java/com/b208/prologue/api/repository/TempPostRepository.java
@@ -2,8 +2,11 @@ package com.b208.prologue.api.repository;
 
 import com.b208.prologue.api.entity.TempPost;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 @Repository
@@ -12,4 +15,8 @@ public interface TempPostRepository extends JpaRepository<TempPost, Long> {
     void deleteByTempPostIdAndGithubId(final Long tempPostId, final String githubId);
     int countByGithubId(final String githubId);
     List<TempPost> findAllByGithubId(final String githubId);
+
+    @Modifying
+    @Query("delete from TempPost t where t.updateTime < :target")
+    void deleteByUpdateTimeBefore(final LocalDateTime target);
 }

--- a/backend/prologue/src/main/java/com/b208/prologue/api/service/AutoSavePostService.java
+++ b/backend/prologue/src/main/java/com/b208/prologue/api/service/AutoSavePostService.java
@@ -11,4 +11,5 @@ public interface AutoSavePostService {
     String getUpdatedTime(final String githubId) throws AutoSavePostException;
     Map<String, Object> getAutoSavePost(final String githubId) throws AutoSavePostException;
     void deleteAutoSavePost(final String githubId) throws Exception;
+    void deleteInvalidDateAutoSavePost();
 }

--- a/backend/prologue/src/main/java/com/b208/prologue/api/service/AutoSavePostServiceImpl.java
+++ b/backend/prologue/src/main/java/com/b208/prologue/api/service/AutoSavePostServiceImpl.java
@@ -7,6 +7,9 @@ import com.b208.prologue.api.request.AutoSavePostRequest;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -59,6 +62,12 @@ public class AutoSavePostServiceImpl implements AutoSavePostService {
     @Override
     public void deleteAutoSavePost(final String githubId) throws Exception {
         autoSavePostRepository.deleteByGithubId(githubId);
+    }
+
+    @Override
+    public void deleteInvalidDateAutoSavePost() {
+        final LocalDateTime today = LocalDate.now().atTime(LocalTime.MIN);
+        autoSavePostRepository.deleteByUpdateTimeBefore(today.minusDays(2));
     }
 
 }

--- a/backend/prologue/src/main/java/com/b208/prologue/api/service/SchedulerService.java
+++ b/backend/prologue/src/main/java/com/b208/prologue/api/service/SchedulerService.java
@@ -10,10 +10,17 @@ import org.springframework.transaction.annotation.Transactional;
 public class SchedulerService {
 
     private final TempPostService tempPostService;
+    private final AutoSavePostService autoSavePostService;
 
     @Transactional
     @Scheduled(cron = "0 30 3 * * *", zone = "Asia/Seoul")
     public void deleteInvalidDateTempPost() {
         tempPostService.deleteInvalidDateTempPost();
+    }
+
+    @Transactional
+    @Scheduled(cron = "0 0 5 * * *", zone = "Asia/Seoul")
+    public void deleteInvalidDateAutoSavePost() {
+        autoSavePostService.deleteInvalidDateAutoSavePost();
     }
 }

--- a/backend/prologue/src/main/java/com/b208/prologue/api/service/SchedulerService.java
+++ b/backend/prologue/src/main/java/com/b208/prologue/api/service/SchedulerService.java
@@ -1,0 +1,19 @@
+package com.b208.prologue.api.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class SchedulerService {
+
+    private final TempPostService tempPostService;
+
+    @Transactional
+    @Scheduled(cron = "0 30 3 * * *", zone = "Asia/Seoul")
+    public void deleteInvalidDateTempPost() {
+        tempPostService.deleteInvalidDateTempPost();
+    }
+}

--- a/backend/prologue/src/main/java/com/b208/prologue/api/service/TempPostService.java
+++ b/backend/prologue/src/main/java/com/b208/prologue/api/service/TempPostService.java
@@ -14,4 +14,5 @@ public interface TempPostService {
     void deleteTempPost(final String githubId, final Long tempPostId) throws Exception;
     int countTempPosts(final String githubId) throws Exception;
     List<TempPostsResponse> getTempPosts(final String githubId) throws Exception;
+    void deleteInvalidDateTempPost();
 }

--- a/backend/prologue/src/main/java/com/b208/prologue/api/service/TempPostServiceImpl.java
+++ b/backend/prologue/src/main/java/com/b208/prologue/api/service/TempPostServiceImpl.java
@@ -10,6 +10,9 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -98,5 +101,12 @@ public class TempPostServiceImpl implements TempPostService {
         }
         return tempPosts;
     }
+
+    @Override
+    public void deleteInvalidDateTempPost() {
+        final LocalDateTime today = LocalDate.now().atTime(LocalTime.MIN);
+        tempPostRepository.deleteByUpdateTimeBefore(today.minusDays(10));
+    }
+
 }
 

--- a/backend/prologue/src/main/java/com/b208/prologue/common/StringListConverter.java
+++ b/backend/prologue/src/main/java/com/b208/prologue/common/StringListConverter.java
@@ -1,0 +1,32 @@
+package com.b208.prologue.common;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import javax.persistence.AttributeConverter;
+import javax.persistence.Convert;
+import java.util.List;
+
+@Convert
+public class StringListConverter implements AttributeConverter<List<String>, String> {
+
+    private final ObjectMapper mapper = new ObjectMapper();
+
+    @Override
+    public String convertToDatabaseColumn(List<String> dataList) {
+        try {
+            return mapper.writeValueAsString(dataList);
+        } catch (JsonProcessingException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Override
+    public List<String> convertToEntityAttribute(String data) {
+        try {
+            return mapper.readValue(data, List.class);
+        } catch (JsonProcessingException e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/backend/prologue/src/test/java/com/b208/prologue/autoSavePost/AutoSavePostRepositoryTest.java
+++ b/backend/prologue/src/test/java/com/b208/prologue/autoSavePost/AutoSavePostRepositoryTest.java
@@ -8,6 +8,10 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+
 import static org.assertj.core.api.Assertions.assertThat;
 
 @DataJpaTest
@@ -91,7 +95,7 @@ class AutoSavePostRepositoryTest {
 
 
     @Test
-    void 자동저장게시글_삭제() {
+    void 자동저장게시글_깃허브ID_기준_삭제() {
         //given
         autoSavePostRepository.save(AutoSavePost.builder()
                 .title("abc")
@@ -106,4 +110,48 @@ class AutoSavePostRepositoryTest {
         assertThat(autoSavePost).isNull();
     }
 
+    @Nested
+    class 자동저장게시글_날짜_기준삭제 {
+        @Test
+        void 삭제할게시글없음() {
+            //given
+            final LocalDateTime today = LocalDate.now().atTime(0, 0);
+            autoSavePostRepository.save(AutoSavePost.builder()
+                    .title("abc")
+                    .githubId(githubId)
+                    .build());
+            autoSavePostRepository.save(AutoSavePost.builder()
+                    .title("abc")
+                    .githubId("abc")
+                    .build());
+
+            //when
+            autoSavePostRepository.deleteByUpdateTimeBefore(today);
+            final List<AutoSavePost> list = autoSavePostRepository.findAll();
+
+            //then
+            assertThat(list).hasSize(2);
+        }
+
+        @Test
+        void 삭제할게시글2개() {
+            //given
+            final LocalDateTime today = LocalDate.now().atTime(0, 0);
+            autoSavePostRepository.save(AutoSavePost.builder()
+                    .title("abc")
+                    .githubId(githubId)
+                    .build());
+            autoSavePostRepository.save(AutoSavePost.builder()
+                    .title("abc")
+                    .githubId("abc")
+                    .build());
+
+            //when
+            autoSavePostRepository.deleteByUpdateTimeBefore(today.plusDays(1));
+            final List<AutoSavePost> list = autoSavePostRepository.findAll();
+
+            //then
+            assertThat(list).hasSize(0);
+        }
+    }
 }

--- a/backend/prologue/src/test/java/com/b208/prologue/autoSavePost/AutoSavePostServiceTest.java
+++ b/backend/prologue/src/test/java/com/b208/prologue/autoSavePost/AutoSavePostServiceTest.java
@@ -132,7 +132,7 @@ class AutoSavePostServiceTest {
     }
 
     @Test
-    void 자동저장게시글_삭제() throws Exception {
+    void 자동저장게시글_깃허브ID_기준_삭제() throws Exception {
         //given
 
         //when
@@ -142,6 +142,19 @@ class AutoSavePostServiceTest {
 
         //verify
         verify(autoSavePostRepository, times(1)).deleteByGithubId(any(String.class));
+    }
+
+    @Test
+    void 자동저장게시글_날짜_기준_삭제() throws Exception {
+        //given
+
+        //when
+        autoSavePostService.deleteInvalidDateAutoSavePost();
+
+        //then
+
+        //verify
+        verify(autoSavePostRepository, times(1)).deleteByUpdateTimeBefore(any(LocalDateTime.class));
     }
 
 }

--- a/backend/prologue/src/test/java/com/b208/prologue/tempPost/TempPostRepositoryTest.java
+++ b/backend/prologue/src/test/java/com/b208/prologue/tempPost/TempPostRepositoryTest.java
@@ -8,6 +8,8 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 
+import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -53,7 +55,7 @@ class TempPostRepositoryTest {
     }
 
     @Test
-    void 임시저장게시글_삭제() {
+    void 임시저장게시글_깃허브ID와TempPostID_기준_삭제() {
         //given
         final TempPost saveTempPost = tempPostRepository.save(TempPost.builder()
                 .title("abc")
@@ -134,4 +136,48 @@ class TempPostRepositoryTest {
         }
     }
 
+    @Nested
+    class 임시저장게시글_날짜_기준삭제 {
+        @Test
+        void 삭제할게시글없음() {
+            //given
+            final LocalDateTime today = LocalDate.now().atTime(0, 0);
+            tempPostRepository.save(TempPost.builder()
+                    .title("abc")
+                    .githubId(githubId)
+                    .build());
+            tempPostRepository.save(TempPost.builder()
+                    .title("abc")
+                    .githubId(githubId)
+                    .build());
+
+            //when
+            tempPostRepository.deleteByUpdateTimeBefore(today);
+            final List<TempPost> list = tempPostRepository.findAll();
+
+            //then
+            assertThat(list).hasSize(2);
+        }
+
+        @Test
+        void 삭제할게시글2개() {
+            //given
+            final LocalDateTime today = LocalDate.now().atTime(0, 0);
+            tempPostRepository.save(TempPost.builder()
+                    .title("abc")
+                    .githubId(githubId)
+                    .build());
+            tempPostRepository.save(TempPost.builder()
+                    .title("abc")
+                    .githubId(githubId)
+                    .build());
+
+            //when
+            tempPostRepository.deleteByUpdateTimeBefore(today.plusDays(1));
+            final List<TempPost> list = tempPostRepository.findAll();
+
+            //then
+            assertThat(list).hasSize(0);
+        }
+    }
 }

--- a/backend/prologue/src/test/java/com/b208/prologue/tempPost/TempPostServiceTest.java
+++ b/backend/prologue/src/test/java/com/b208/prologue/tempPost/TempPostServiceTest.java
@@ -14,6 +14,7 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -131,7 +132,7 @@ class TempPostServiceTest {
     }
 
     @Test
-    void 임시저장게시글_삭제() throws Exception {
+    void 임시저장게시글_깃허브ID와TempPostID_기준_삭제() throws Exception {
         //given
 
         //when
@@ -174,5 +175,18 @@ class TempPostServiceTest {
 
         //then
         assertThat(list).hasSize(2);
+    }
+
+    @Test
+    void 임시저장게시글_날짜_기준삭제() throws Exception {
+        //given
+
+        //when
+        tempPostService.deleteInvalidDateTempPost();
+
+        //then
+
+        //verify
+        verify(tempPostRepository, times(1)).deleteByUpdateTimeBefore(any(LocalDateTime.class));
     }
 }


### PR DESCRIPTION
close #36 

- `tags` 가 저장되는 방식을 변경하였습니다. 기존에는 따로 `tags`테이블로 분리하여 저장하였지만, `tags`를 문자열로 저장해 컬럼으로 관리하는 것으로 변경하였습니다.
- `description`컬럼이 Mysql 예약어로 지정되어잇어서, Mysql상 컬럼명을 변경했습니다.
---
- 매일 일정한 시간에 기간이 지난 임시저장글과 자동저장글을 DB에서 삭제하기 위해 스프링 스케줄러를 활용했습니다.
- 임시저장글은 매일 3시 30분에 10일이 지난 임시저장글을 , 자동저장글은 매일 5시에 2일이 지난 자동저장글을 삭제하는 로직이 동작합니다.
- 업데이트 날짜 기준으로 삭제를 시키다보니 성능을 위해서 JPA의 `deleteBy`메소드를 활용하지 않고, `Query`어노테이션을 활용하여 sql문을 한번만 실행하여 삭제할 수 있도록 구현했습니다.