### PR TITLE
[FE] 임시저장 개수 및 목록 조회 API 연결

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -22,6 +22,7 @@
         "axios": "^1.1.3",
         "canvas-confetti": "^1.6.0",
         "cssjson": "^2.1.3",
+        "dayjs": "^1.11.11",
         "eslint-config-prettier": "^9.1.0",
         "moment": "^2.29.4",
         "patch-package": "^6.5.0",
@@ -7416,6 +7417,11 @@
       "engines": {
         "node": ">=10"
       }
+    },
+    "node_modules/dayjs": {
+      "version": "1.11.11",
+      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.11.tgz",
+      "integrity": "sha512-okzr3f11N6WuqYtZSvm+F776mB41wRZMhKP+hc34YdW+KmtYYK9iqvHSwo2k9FEH3fhGXvOPV6yz2IcSrfRUDg=="
     },
     "node_modules/debug": {
       "version": "4.3.4",
@@ -25695,6 +25701,11 @@
         "whatwg-mimetype": "^2.3.0",
         "whatwg-url": "^8.0.0"
       }
+    },
+    "dayjs": {
+      "version": "1.11.11",
+      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.11.tgz",
+      "integrity": "sha512-okzr3f11N6WuqYtZSvm+F776mB41wRZMhKP+hc34YdW+KmtYYK9iqvHSwo2k9FEH3fhGXvOPV6yz2IcSrfRUDg=="
     },
     "debug": {
       "version": "4.3.4",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -16,6 +16,7 @@
     "axios": "^1.1.3",
     "canvas-confetti": "^1.6.0",
     "cssjson": "^2.1.3",
+    "dayjs": "^1.11.11",
     "eslint-config-prettier": "^9.1.0",
     "moment": "^2.29.4",
     "patch-package": "^6.5.0",

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -7,7 +7,7 @@ import SettingPage from "pages/setting/SettingPage";
 import PostRouterPage from "features/post/PostRouter";
 import BlogReset from "pages/BlogResetPage";
 import GatsbyLayout from "pages/GatsbyLayoutPage";
-import PageRouterPage from "pages/post/PageRouterPage";
+import PageRouterPage from "pages/PageRouterPage";
 import LoginOAuthHandler from "features/landing/LoginOAuthHandler";
 import AuthRoute from "./AuthRoute";
 

--- a/frontend/src/apis/Api.ts
+++ b/frontend/src/apis/Api.ts
@@ -7,6 +7,7 @@ import { ModifiedPageConfig } from "pages/PageSettingPage";
 import { UserInfoConfig } from "interfaces/auth.interface";
 import { PostListConfig } from "stores/postStore";
 import { MyBlogInfoConfig, MyInfoConfig } from "interfaces/setting.interface";
+import { TempPostConfig } from "interfaces/post.interface";
 
 type ServerResponse = {
   message?: string; // 메시지
@@ -130,4 +131,9 @@ export const postApi = {
   getPage: (accessToken: string, githubId: string, pageName: string) =>
     Get(api.posts.getPage(accessToken, githubId, pageName)),
   putPage: (data: { data: Blob }) => Put(api.posts.modifyPage(), data),
+};
+
+export const tempApi = {
+  getTempListCnt: (githubId: string) => Get<{ count: number }>(api.temp.getTempListCnt(githubId)),
+  getTempList: (githubId: string) => Get<{ data: TempPostConfig[] }>(api.temp.getTempList(githubId)),
 };

--- a/frontend/src/apis/BaseUrl.ts
+++ b/frontend/src/apis/BaseUrl.ts
@@ -6,7 +6,9 @@ const AUTH = "auth/";
 const BLOG = "blog/";
 const DASHBOARD = "dashboard/";
 const SETTING = "setting/";
-const POSTS = "posts";
+const POSTS = "posts/";
+const TEMP = "temp-posts/";
+const AUTO = "auto-post/";
 
 interface apiInterface {
   auth: {
@@ -55,6 +57,18 @@ interface apiInterface {
     getPostList: (accessToken: string, githubId: string, index: number, category: string) => string;
     getPage: (accessToken: string, githubId: string, pageName: string) => string;
     modifyPage: () => string;
+  };
+  temp: {
+    getTempListCnt: (githubId: string) => string;
+    getTempList: (githubId: string) => string;
+    getTempPost: (githubId: string, tempPostId: number) => string;
+    writeTempPost: () => string;
+    deleteTempPost: (githubId: string, tempPostId: number) => string;
+  };
+  auto: {
+    saveAutoPost: () => string;
+    getAutoPost: (githubId: string) => string;
+    getIsAutoPost: (githubId: string) => string;
   };
 }
 
@@ -135,6 +149,20 @@ const api: apiInterface = {
     getPage: (accessToken: string, githubId: string, pageName: string) =>
       HOST + POSTS + "/pages?accessToken=" + accessToken + "&githubId=" + githubId + "&pageName=" + pageName,
     modifyPage: () => HOST + POSTS + "/pages",
+  },
+  temp: {
+    getTempListCnt: (githubId: string) => HOST + TEMP + "/count?githubId=" + githubId,
+    getTempList: (githubId: string) => HOST + TEMP + "/list?githubId=" + githubId,
+    getTempPost: (githubId: string, tempPostId: number) =>
+      HOST + TEMP + "?githubId=" + githubId + "&tempPostId=" + tempPostId,
+    writeTempPost: () => HOST + TEMP,
+    deleteTempPost: (githubId: string, tempPostId: number) =>
+      HOST + TEMP + "?githubId=" + githubId + "&tempPostId=" + tempPostId,
+  },
+  auto: {
+    saveAutoPost: () => HOST + AUTO,
+    getAutoPost: (githubId: string) => HOST + AUTO + "?githubId=" + githubId,
+    getIsAutoPost: (githubId: string) => HOST + AUTO + "/exist?githubId=" + githubId,
   },
 };
 

--- a/frontend/src/apis/api/temp.ts
+++ b/frontend/src/apis/api/temp.ts
@@ -1,0 +1,13 @@
+import { tempApi } from "apis/Api";
+
+const getTempListCnt = async (githubId: string) => {
+  const res = await tempApi.getTempListCnt(githubId);
+  return res.data.count;
+};
+
+const getTempList = async (githubId: string) => {
+  const res = await tempApi.getTempList(githubId);
+  return res.data.data;
+};
+
+export { getTempListCnt, getTempList };

--- a/frontend/src/features/post/PostTempModal.tsx
+++ b/frontend/src/features/post/PostTempModal.tsx
@@ -1,28 +1,41 @@
+import { useEffect, useState } from "react";
 import styles from "styles/PostWrite.module.css";
 import Text from "components/Text";
 import Button from "components/Button";
 import Tooltip from "components/Tooltip";
 import { Drawer } from "@mui/material";
 import DeleteOutlineIcon from "@mui/icons-material/DeleteOutline";
+import { useAuthStore } from "stores/authStore";
+import { getTempList } from "apis/api/temp";
+import { TempPostConfig } from "interfaces/post.interface";
+import dayjs from "dayjs";
 
 interface Props {
   open: boolean;
   onClose: () => void;
 }
 
+const stringToDate = (date: string) => {
+  const typedDate = new Date(date);
+  return dayjs(typedDate).format("YYYY-MM-DD");
+};
+
 const PostTempModal = ({ open, onClose }: Props) => {
-  const tempList = [
-    { date: "2024.01.01", title: "제목 없음", content: "" },
-    { date: "2024.01.01", title: "hi~ hihihi", content: "" },
-    { date: "2024.01.01", title: "[Algorithm] 비트마스킹 (Bitmasking)", content: "asdfasdfasdf" },
-    { date: "2024.01.01", title: "[Prologue] 프롤로그 개선기 #1. 환경 개선", content: "asdfasdfasdf" },
-    { date: "2024.01.01", title: "[Prologue] 프롤로그 개선기 #1. 환경 개선", content: "asdfasdfasdf" },
-    { date: "2024.01.01", title: "[Prologue] 프롤로그 개선기 #1. 환경 개선", content: "asdfasdfasdf" },
-    { date: "2024.01.01", title: "[Prologue] 프롤로그 개선기 #1. 환경 개선", content: "asdfasdfasdf" },
-    { date: "2024.01.01", title: "[Prologue] 프롤로그 개선기 #1. 환경 개선", content: "asdfasdfasdf" },
-    { date: "2024.01.01", title: "[Prologue] 프롤로그 개선기 #1. 환경 개선", content: "asdfasdfasdf" },
-    { date: "2024.01.01", title: "[Prologue] 프롤로그 개선기 #1. 환경 개선", content: "asdfasdfasdf" },
-  ];
+  const githubId = useAuthStore((state) => state.githubId);
+  const [tempList, setTempList] = useState<TempPostConfig[]>([]);
+  const getTempLists = async () => {
+    const res = await getTempList(githubId);
+    setTempList(res);
+  };
+
+  const saveTempItem = () => {
+    console.log("save");
+  };
+
+  useEffect(() => {
+    getTempLists();
+  }, []);
+
   return (
     <Drawer anchor="bottom" open={open} onClose={onClose}>
       <div className={styles.temp__container}>
@@ -35,12 +48,12 @@ const PostTempModal = ({ open, onClose }: Props) => {
             {tempList.map((item, i) => {
               return (
                 <div key={i}>
-                  <Text value={item.date} type="caption" />
+                  <Text value={stringToDate(item.updatedAt)} type="caption" />
                   <div>
                     <Text value={item.title} type="caption" />
                     <DeleteOutlineIcon className={styles["delete"]} />
                     <div className={styles["tooltip"]}>
-                      <Tooltip>{item.content === "" ? "[ 내용 없음 ]" : item.content}</Tooltip>
+                      <Tooltip>{item.summary === "" ? "[ 내용 없음 ]" : item.summary}</Tooltip>
                     </div>
                   </div>
                 </div>
@@ -49,7 +62,7 @@ const PostTempModal = ({ open, onClose }: Props) => {
           </div>
           <div className={styles["temp__button--save"]}>
             <Button color="gray" label="취소" onClick={onClose} />
-            <Button color="blue" label="임시저장" />
+            <Button color="blue" label="임시저장" onClick={saveTempItem} />
           </div>
         </div>
       </div>

--- a/frontend/src/interfaces/post.interface.ts
+++ b/frontend/src/interfaces/post.interface.ts
@@ -1,0 +1,6 @@
+export interface TempPostConfig {
+  tempPostId: number;
+  title: string;
+  summary: string;
+  updatedAt: string;
+}

--- a/frontend/src/pages/PageRouterPage.tsx
+++ b/frontend/src/pages/PageRouterPage.tsx
@@ -1,6 +1,6 @@
 import { Route, Routes } from "react-router-dom";
 import styles from "styles/Post.module.css";
-import PageEditPage from "../NotUsed/PageEditPage";
+import PageEditPage from "./NotUsed/PageEditPage";
 
 const PageRouterPage = () => {
   return (

--- a/frontend/src/pages/post/PostWritePage.tsx
+++ b/frontend/src/pages/post/PostWritePage.tsx
@@ -13,6 +13,7 @@ import { useAuthStore } from "stores/authStore";
 import { useShallow } from "zustand/react/shallow";
 import { useNavigate, useParams } from "react-router-dom";
 import { deletePostApi } from "apis/api/posts";
+import { getTempListCnt } from "apis/api/temp";
 import Modal from "components/Modal";
 import PostTempModal from "features/post/PostTempModal";
 import Axios from "apis/MultipartAxios";
@@ -56,6 +57,11 @@ const PostWritePage = () => {
   const [isAutoTempExist, setIsAutoTempExist] = useState(true);
   const [tempListCnt, setTempListCnt] = useState(0);
 
+  const getTempListCount = async () => {
+    const res = await getTempListCnt(githubId);
+    setTempListCnt(res);
+  };
+
   const handleSave = async () => {
     if (title == "") {
       setSaveModalOpen(false);
@@ -75,8 +81,6 @@ const PostWritePage = () => {
 
     if (title != "" && description != "" && content != "") {
       const formData = new FormData();
-      console.log(fileList);
-      console.log(files);
       for (let i = 0; i < files.length; i++) {
         formData.append("files", files[i]);
       }
@@ -95,7 +99,6 @@ const PostWritePage = () => {
         "\n---\n";
 
       if (isEdit === "수정") {
-        console.log("isEdit: ", isEdit);
         const tmpArray = [];
 
         if (fileList.length) {
@@ -186,6 +189,8 @@ const PostWritePage = () => {
   const showDeleteModal = () => setDeleteModalOpen(true);
 
   useEffect(() => {
+    getTempListCount();
+
     if (isAutoTempExist && isEdit === "작성") {
       const result = setTimeout(() => {
         confirm(`${autoTempTime}에 저장된 글이 있습니다.\n이어서 작성하시겠습니까?`);


### PR DESCRIPTION
close #38 

1. 임시저장 목록 조회 API 연결

2. 임시저장 개수 조회 API 연결
- 임시저장 목록이 추가되었을 때, 부모 컴포넌트에 있는 개수도 갱신되어야 함. 
- 해당 부분은 임시저장 글이 추가될 때 개선할 예정. **-> #47 해결 !**