### PR TITLE
[FE] 임시저장 작성 API 연결

### DIFF
--- a/frontend/src/apis/Api.ts
+++ b/frontend/src/apis/Api.ts
@@ -138,6 +138,14 @@ export const tempApi = {
   getTempList: (githubId: string) => Get<{ data: TempPostConfig[] }>(api.temp.getTempList(githubId)),
   getTempPost: (githubId: string, tempPostId: number) =>
     Get<TempPostDetailConfig>(api.temp.getTempPost(githubId, tempPostId)),
+  writeTempPost: (data: {
+    githubId: string;
+    title: string;
+    description: string;
+    category: string;
+    tags: string[];
+    content: string;
+  }) => Post<{ tempPostId: number }>(api.temp.writeTempPost(), data),
 };
 
 export const autoApi = {

--- a/frontend/src/apis/Api.ts
+++ b/frontend/src/apis/Api.ts
@@ -5,9 +5,8 @@ import api from "./BaseUrl";
 import { DetailConfig } from "pages/setting/DetailSettingPage";
 import { ModifiedPageConfig } from "pages/PageSettingPage";
 import { UserInfoConfig } from "interfaces/auth.interface";
-import { PostListConfig } from "stores/postStore";
 import { MyBlogInfoConfig, MyInfoConfig } from "interfaces/setting.interface";
-import { TempPostConfig, TempPostDetailConfig } from "interfaces/post.interface";
+import { PostListConfig, TempPostConfig, TempPostDetailConfig } from "interfaces/post.interface";
 
 type ServerResponse = {
   message?: string; // 메시지

--- a/frontend/src/apis/api/temp.ts
+++ b/frontend/src/apis/api/temp.ts
@@ -15,4 +15,15 @@ const getTempPost = async (githubId: string, tempPostId: number) => {
   return res.data;
 };
 
-export { getTempListCnt, getTempList, getTempPost };
+const writeTempPost = async (data: {
+  githubId: string;
+  title: string;
+  description: string;
+  category: string;
+  tags: string[];
+  content: string;
+}) => {
+  await tempApi.writeTempPost(data);
+};
+
+export { getTempListCnt, getTempList, getTempPost, writeTempPost };

--- a/frontend/src/features/post/PostEditor.tsx
+++ b/frontend/src/features/post/PostEditor.tsx
@@ -27,7 +27,7 @@ const PostEditor = () => {
 
   useEffect(() => {
     editorRef.current.getInstance().setMarkdown(editPost.content);
-  }, [editPost]);
+  }, [editPost.content]);
 
   return (
     <div className={styles.editor}>

--- a/frontend/src/features/post/PostList.tsx
+++ b/frontend/src/features/post/PostList.tsx
@@ -4,9 +4,10 @@ import PostListCard from "./PostListCard";
 import { useNavigate } from "react-router-dom";
 import { CircularProgress } from "@mui/material";
 import { getPostDetailApi, getPostListApi } from "apis/api/posts";
-import { PostListConfig, usePostActions, usePostStore } from "stores/postStore";
+import { usePostActions, usePostStore } from "stores/postStore";
 import { useAuthStore } from "stores/authStore";
 import { useShallow } from "zustand/react/shallow";
+import { PostListConfig } from "interfaces/post.interface";
 
 interface PostListProps {
   category: string;

--- a/frontend/src/features/post/PostTempModal.tsx
+++ b/frontend/src/features/post/PostTempModal.tsx
@@ -9,6 +9,7 @@ import { useAuthStore } from "stores/authStore";
 import { getTempList, getTempPost, writeTempPost } from "apis/api/temp";
 import { TempPostConfig } from "interfaces/post.interface";
 import dayjs from "dayjs";
+import { usePostActions, usePostStore } from "stores/postStore";
 import { useShallow } from "zustand/react/shallow";
 
 interface Props {

--- a/frontend/src/features/post/PostTempModal.tsx
+++ b/frontend/src/features/post/PostTempModal.tsx
@@ -6,10 +6,10 @@ import Tooltip from "components/Tooltip";
 import { Drawer } from "@mui/material";
 import DeleteOutlineIcon from "@mui/icons-material/DeleteOutline";
 import { useAuthStore } from "stores/authStore";
-import { getTempList, getTempPost } from "apis/api/temp";
+import { getTempList, getTempPost, writeTempPost } from "apis/api/temp";
 import { TempPostConfig } from "interfaces/post.interface";
 import dayjs from "dayjs";
-import { usePostActions } from "stores/postStore";
+import { useShallow } from "zustand/react/shallow";
 
 interface Props {
   open: boolean;
@@ -23,6 +23,7 @@ const stringToDate = (date: string) => {
 
 const PostTempModal = ({ open, onClose }: Props) => {
   const githubId = useAuthStore((state) => state.githubId);
+  const editPost = usePostStore(useShallow((state) => state.editPost));
   const [tempList, setTempList] = useState<TempPostConfig[]>([]);
   const { setEditPostAction } = usePostActions();
 
@@ -31,8 +32,18 @@ const PostTempModal = ({ open, onClose }: Props) => {
     setTempList(res);
   };
 
-  const saveTempItem = () => {
-    console.log("save");
+  const saveTempItem = async () => {
+    const { title, description, category, tagList, content } = editPost;
+    const data = {
+      githubId,
+      title,
+      description,
+      category,
+      tags: tagList,
+      content,
+    };
+    await writeTempPost(data);
+    getTempLists();
   };
 
   const setEditPost = async (id: number) => {

--- a/frontend/src/interfaces/post.interface.ts
+++ b/frontend/src/interfaces/post.interface.ts
@@ -1,3 +1,27 @@
+export interface PostCommonConfig {
+  title: string;
+  description: string;
+  category: string;
+}
+
+export interface PostListConfig extends PostCommonConfig {
+  tag: string[];
+  date: string;
+  directory: string;
+  imgUrl: string;
+}
+
+export interface PostDetailConfig extends PostCommonConfig {
+  content: string;
+  tagList: string[];
+  fileList?: any[];
+  files?: any[];
+  images?: {
+    name: string;
+    url: string;
+  }[];
+}
+
 export interface TempPostConfig {
   tempPostId: number;
   title: string;

--- a/frontend/src/slices/postSlice.ts
+++ b/frontend/src/slices/postSlice.ts
@@ -1,15 +1,6 @@
 import { createSlice } from "@reduxjs/toolkit";
 import { rootState } from "app/store";
-
-export interface PostListConfig {
-  title: string;
-  date: string;
-  description: string;
-  category: string;
-  tag: string[];
-  directory: string;
-  imgUrl: string;
-}
+import { PostListConfig } from "interfaces/post.interface";
 
 interface editListConfig {
   title: string;

--- a/frontend/src/stores/postStore.ts
+++ b/frontend/src/stores/postStore.ts
@@ -1,29 +1,6 @@
+import { PostDetailConfig, PostListConfig } from "interfaces/post.interface";
 import { create } from "zustand";
 import { immer } from "zustand/middleware/immer";
-
-interface PostCommonConfig {
-  title: string;
-  description: string;
-  category: string;
-}
-
-export interface PostListConfig extends PostCommonConfig {
-  tag: string[];
-  date: string;
-  directory: string;
-  imgUrl: string;
-}
-
-export interface PostDetailConfig extends PostCommonConfig {
-  content: string;
-  tagList: string[];
-  fileList?: any[];
-  files?: any[];
-  images?: {
-    name: string;
-    url: string;
-  }[];
-}
 
 interface State {
   editPost: PostDetailConfig;


### PR DESCRIPTION
close #44 

1. 임시저장 작성 API 연결
2. post interface 별도의 파일로 이동하고, 경로 변경.
3. <PostEditor /> 로딩이 되고, 임시저장된 글로 editor를 변경할 때 content 부분만 변경이 안되어서,
```jsx
  useEffect(() => {
    editorRef.current.getInstance().setMarkdown(editPost.content);
  }, [editPost]);
```
이렇게 작성했더니, 게시글 정보 (제목, 설명,...) 이 변경될 때마다 마우스의 포커스가 content로 넘어가는 문제가 있었다.
```jsx
  useEffect(() => {
    editorRef.current.getInstance().setMarkdown(editPost.content);
  }, [editPost.content]);
```
그래서 content의 내용이 변경될 때마다 포커스를 옮겨주도록 했는데, 문제는 content에 내용이 임력될 때마다 저 함수가 실행된다는 것.
문제를 어떻게 해결해야 할지 API 연결 해보고 고민해봐야겠다 ...